### PR TITLE
Generate and upload AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: xenial
+
+before_install:
+  - sudo add-apt-repository ppa:beineri/opt-qt-5.11.1-xenial -y
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get -y install qt511base libgl1-mesa-dev
+  - source /opt/qt*/bin/qt*-env.sh
+
+script:
+  - qmake CONFIG+=release PREFIX=/usr
+  - make -j$(nproc)
+  # make INSTALL_ROOT=appdir -j$(nproc) install ; find appdir/ # FIXME: Make this work
+  - mkdir -p appdir/usr/bin # FIXME: make install should do this
+  - cp QTjsonDiff appdir/usr/bin/qtjsondiff # FIXME: make install should do this
+  - mkdir -p appdir/usr/share/icons/hicolor/256x256/apps/ # FIXME: make install should do this
+  - cp diff.png appdir/usr/share/icons/hicolor/256x256/apps/diff.png # FIXME: make install should do this
+  - mkdir -p appdir/usr/share/applications/ # FIXME: make install should do this
+  - cp qtjsondiff.desktop appdir/usr/share/applications/ # FIXME: make install should do this
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
+
+after_success:
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh Qt*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/qtjsondiff.desktop
+++ b/qtjsondiff.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Categories=Development;
+Name=Qt JSON diff
+Exec=qtjsondiff %F
+Icon=diff
+Comment=Qt JSON diff


### PR DESCRIPTION
Closes #6

Generate and upload AppImage built on [Travis CI](https://travis-ci.org/).

__PLEASE NOTE:__ For this to work, you need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.