### PR TITLE
let's make it functional in dark themes too

### DIFF
--- a/qjsonitem.cpp
+++ b/qjsonitem.cpp
@@ -97,6 +97,9 @@ void QJsonTreeItem::setIdxRelation(QModelIndex idxPointer)
 void QJsonTreeItem::setColor(const QColor &color)
 {
         mColor = color;
+        // alpha helps with readability in case of alternating
+        // background row colors and in dark-ish themes
+        mColor.setAlpha(100);
 }
 
 /* Get index of relation from another model

--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -134,7 +134,9 @@ QVariant QJsonModel::data(const QModelIndex &index, int role) const
     {
         if(!item->color().isValid())
         {
-            return QColor(Qt::white);
+            // Let's not use white color. It breaks dark themes
+            // and alternating background row colors too.
+            return QPalette::Base;
         }
         else
         {
@@ -150,6 +152,10 @@ QVariant QJsonModel::data(const QModelIndex &index, int role) const
     if ((role == Qt::DecorationRole) && (index.column() == 0)){
 
         return mTypeIcons.value(item->type());
+    }
+
+    if (role == Qt::DecorationRole) {
+        return QPalette::Text; // Theme color for text
     }
 
     if (role == Qt::DisplayRole) {


### PR DESCRIPTION
 - do not enforce white background
 - make background colors for diff transparent a bit to work
   with white text color