### PR TITLE
Enhance diff editing support and fix related issues

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -138,7 +138,7 @@ jobs:
 #         sudo add-apt-repository ppa:beineri/opt-qt-5.15.4-focal -y
       - name: install qt into linux
         if: matrix.config.os == 'ubuntu-22.04' && (github.ref == 'refs/heads/main' || needs.create_release.outputs.build_lin == '1')
-        run:  sudo apt-get -y install debhelper dput devscripts qt6-base-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools libgl1-mesa-dev libssl-dev libqt6charts6-dev libqt6serialport6-dev libssl-dev zlib1g-dev libfuse2
+        run:  sudo apt-get -y install debhelper dput devscripts qt6-base-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools libgl1-mesa-dev libssl-dev libqt6charts6-dev libqt6serialport6-dev libssl-dev zlib1g-dev libfuse2  qt6-image-formats-plugins
       - name: Set up GPG
         if: matrix.config.os == 'ubuntu-22.04' && (github.ref == 'refs/heads/main' || needs.create_release.outputs.build_lin == '1')
         run: |

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -20,8 +20,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check commit message
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          if [[ "${{ github.event.head_commit.message }}" == *"[skip ci]"* ]]; then
+          if [[ "$COMMIT_MSG" == *"[skip ci]"* ]]; then
             echo "Skipping workflow"
             exit 1
           fi
@@ -47,32 +49,26 @@ jobs:
         id: build
       - name: Generate release notes
         id: generate_notes
+        shell: bash
         run: |
+          set -euo pipefail
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -n "$LAST_TAG" ]; then
-            echo "Generating notes since last tag: $LAST_TAG"
-            COMMIT_LOG=$(git log ${LAST_TAG}..HEAD --pretty=format:"* %s (%h)")
+            git log "${LAST_TAG}..HEAD" --pretty=format:"* %s (%h)" > release_notes.md
           else
-            echo "No previous tag found. Generating notes for all commits."
-            COMMIT_LOG=$(git log --pretty=format:"* %s (%h)")
+            git log --pretty=format:"* %s (%h)" > release_notes.md
           fi
-
-          {
-            echo "changelog_body<<EOF"
-            echo "$COMMIT_LOG"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Debug changelog body
+      - name: Debug release notes
         run: |
-          echo "--- Start of Changelog Body ---"
-          echo "${{ steps.generate_notes.outputs.changelog_body }}"
-          echo "--- End of Changelog Body ---"
+          echo "--- Start release_notes.md ---"
+          sed -n '1,120p' release_notes.md
+          echo "--- End release_notes.md ---"
       - name: Create release
         if: github.ref == 'refs/heads/main'
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
-          body: ${{ steps.generate_notes.outputs.changelog_body }}
+          body_path: release_notes.md
           tag_name: ${{ steps.build.outputs.VER_TAG_NAME }}_${{ github.ref }}
           name: Release CI ${{ steps.build.outputs.VER_TAG_NAME }} ${{ github.ref }}
           draft: false
@@ -81,11 +77,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set build flags from PR tags or commit message
         id: set_flags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          if [[ "${{ github.event_name }}" = "pull_request" ]]; then
-            SRC="${{ github.event.pull_request.title }} ${{ github.event.pull_request.body }}"
+          if [[ "$EVENT_NAME" = "pull_request" ]]; then
+            SRC="$PR_TITLE $PR_BODY"
           else
-            SRC="${{ github.event.head_commit.message }}"
+            SRC="$COMMIT_MSG"
           fi
 
           BUILD_MAC_DMG=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ window geometry.
 ## Edit mode
 
 Edit mode was added on branch `edit`. It is off by default to preserve
-the widget's prior read-only behaviour.
+the widget's prior read-only behavior.
 
 - `QJsonModel::setEditable(bool)` is the master switch.
   `MainWindow` calls `messageJsonCont->setEditable(true)` on the
@@ -179,7 +179,7 @@ Pattern for version-guarded code:
 #endif
 ```
 
-If a change requires Qt 6-only behaviour and a fallback isn't
+If a change requires Qt 6-only behavior and a fallback isn't
 practical, raise it before introducing the dependency.
 
 ## Things to be careful about

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Some features:
     - **Inline Editing** (opt-in): Edit keys, types and values directly within the tree view.
       Toggle from **Preferences → JSON Editing**.
       * **Single-tree tab**: right-click → *Add child* / *Delete row*.
-      * **Diff tab**: each side gets a toolbar arrow that resolves the selected difference — for paired rows it overwrites the other side's value with this side's; for rows that exist only here, it inserts a copy on the other side. A *Delete here* button removes the selected row (the peer on the other side becomes *NotPresent* until you delete or push it too). Colours update live as you edit — no need to press *Compare* again. Renaming a key detaches the pair (both sides become *NotPresent*); changing a value or type marks the pair *Huge*.
+      * **Diff tab**: each side gets a toolbar arrow that resolves the selected difference — for paired rows it overwrites the other side's value with this side's; for rows that exist only here, it inserts a copy on the other side. A *Delete here* button removes the selected row (the peer on the other side becomes *NotPresent* until you delete or push it too). Colors update live as you edit — no need to press *Compare* again. Renaming a key detaches the pair (both sides become *NotPresent*); changing a value or type marks the pair *Huge*.
     - **Threaded Compare with Progress + Cancel**: the *Compare* button runs on a worker thread; a modal progress dialog shows progress per node and a *Cancel* button aborts the run safely. The trees stay blocked from input until the compare finishes so the snapshot stays consistent.
     - **Search**: Full search functionality (forward, backward, case-sensitive) for both text and tree views.
     - **JSON Comparison**: Compare two JSON documents with highlighting for differences, synchronized scrolling, and synchronized item selection in tree view.
@@ -50,7 +50,7 @@ Some features:
       * **Expand/Collapse Selected**: Expands or collapses the currently selected items.
       * **Expand/Collapse Recursively**: Expands or collapses the selected items and all their children.
     - **Configurable** (Preferences, persisted via `QSettings`):
-      * Colours for *Identical*, *Moderate*, *Huge*, *NotPresent* + a global alpha; syntax highlighter colours; one-click restore-to-defaults.
+      * Colors for *Identical*, *Moderate*, *Huge*, *NotPresent* + a global alpha; syntax highlighter colors; one-click restore-to-defaults.
       * Tab position (north/south/west/east), JSON-view button position.
       * Keyboard shortcuts for every clipboard action (editable in-table, restorable).
       * **JSON Editing** toggles for the single-tree tab and the diff view.
@@ -200,7 +200,7 @@ Create objects and define their properties:
     // opt-in to inline diff editing: both trees become editable,
     // per-side toolbar arrows resolve Huge differences and push
     // NotPresent rows to the other side, and Delete here removes
-    // the selected row. Colours refresh live as the user edits.
+    // the selected row. Colors refresh live as the user edits.
     //differ->setDiffEditable(true);
     // set some text to left diff view
     QJsonDocument data22=QJsonDocument::fromJson("{\"empty\":\"empty\"}");

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ Some features:
 
     - **Dual View Modes**: Switch between a formatted JSON text view and an interactive tree view.
     - **Data Loading**: Load JSON from a file, a URL, or by pasting directly into the tree view (Ctrl+V).
-    - **Inline Editing**: Edit keys and values directly within the tree view.
+    - **Inline Editing** (opt-in): Edit keys, types and values directly within the tree view.
+      Toggle from **Preferences → JSON Editing**.
+      * **Single-tree tab**: right-click → *Add child* / *Delete row*.
+      * **Diff tab**: each side gets a toolbar arrow that resolves the selected difference — for paired rows it overwrites the other side's value with this side's; for rows that exist only here, it inserts a copy on the other side. A *Delete here* button removes the selected row (the peer on the other side becomes *NotPresent* until you delete or push it too). Colours update live as you edit — no need to press *Compare* again. Renaming a key detaches the pair (both sides become *NotPresent*); changing a value or type marks the pair *Huge*.
+    - **Threaded Compare with Progress + Cancel**: the *Compare* button runs on a worker thread; a modal progress dialog shows progress per node and a *Cancel* button aborts the run safely. The trees stay blocked from input until the compare finishes so the snapshot stays consistent.
     - **Search**: Full search functionality (forward, backward, case-sensitive) for both text and tree views.
     - **JSON Comparison**: Compare two JSON documents with highlighting for differences, synchronized scrolling, and synchronized item selection in tree view.
     - **Array Sorting**: Sort objects within arrays to simplify comparison when order is not important.
@@ -45,6 +49,12 @@ Some features:
     - **Tree Expansion**:
       * **Expand/Collapse Selected**: Expands or collapses the currently selected items.
       * **Expand/Collapse Recursively**: Expands or collapses the selected items and all their children.
+    - **Configurable** (Preferences, persisted via `QSettings`):
+      * Colours for *Identical*, *Moderate*, *Huge*, *NotPresent* + a global alpha; syntax highlighter colours; one-click restore-to-defaults.
+      * Tab position (north/south/west/east), JSON-view button position.
+      * Keyboard shortcuts for every clipboard action (editable in-table, restorable).
+      * **JSON Editing** toggles for the single-tree tab and the diff view.
+      * Optional restore-last-loaded-paths on startup.
 
 
 JSON Tree View
@@ -174,18 +184,24 @@ You need to create some UI elements where you can put those objects.
 
 Create objects and define their properties:
 ```cpp
-    
+
     // create json treeview and set tab as parent
     messageJsonCont=new QJsonContainer(ui->jsonview_tab);
     // you can hide address line and browse button
     //messageJsonCont->setBrowseVisible(false);
-    // you can let users edit keys, values and types inline
+    // you can let users edit keys, values and types inline (and
+    // unlock the Add child / Delete row context-menu items)
     //messageJsonCont->setEditable(true);
     // you can set json text
     messageJsonCont->loadJson(QString("{\"empty\":\"empty\"}"));
-    
+
     // create json diff like tree view set some tab as parrent
     differ=new QJsonDiff(ui->compare_tab);
+    // opt-in to inline diff editing: both trees become editable,
+    // per-side toolbar arrows resolve Huge differences and push
+    // NotPresent rows to the other side, and Delete here removes
+    // the selected row. Colours refresh live as the user edits.
+    //differ->setDiffEditable(true);
     // set some text to left diff view
     QJsonDocument data22=QJsonDocument::fromJson("{\"empty\":\"empty\"}");
     differ->loadJsonLeft(data22);
@@ -194,7 +210,27 @@ Create objects and define their properties:
     differ->loadJsonRight(data11);
 ```
 
-That's all pretty simple.
+That's all pretty simple. Both edit-mode switches are off by default
+so the original read-only widget contract is preserved.
+
+If you'd like to bind your own shortcuts to the edit actions instead
+of going through the toolbar / context menu, every action is exposed
+as a public slot:
+
+```cpp
+// Diff widget
+differ->pushLeftSelectionToRight();
+differ->pushRightSelectionToLeft();
+differ->deleteLeftSelection();
+differ->deleteRightSelection();
+
+// Single tree
+messageJsonCont->addChildOf(parentIndex);   // returns the new row
+messageJsonCont->removeAt(targetIndex);
+```
+
+All of them no-op when their side's edit mode is off, so you can
+wire them up unconditionally.
 
 If you want to run a comparison without the widget (for example in a CLI tool or a background job), you can use `JsonDiffEngine` directly:
 

--- a/jsondiffengine.cpp
+++ b/jsondiffengine.cpp
@@ -533,6 +533,47 @@ void JsonDiffEngine::apply(const DiffNode &snap, QJsonModel *model, QJsonModel *
     emit model->dataUpdated();
 }
 
+void JsonDiffEngine::applyPath(const DiffNode &snap, QJsonModel *model,
+                               const QList<int> &path, QJsonModel *otherModel)
+{
+    if (!model || path.isEmpty())
+        return;
+
+    const DiffNode *node = &snap;
+    QModelIndex parent;
+    const int last = model->columnCount() - 1;
+    // Walk from root down to `path`. Every step is an ancestor of the
+    // edited node whose color/idxRelation may have shifted (Moderate ↔
+    // Identical) as a result of the edit. Emit dataChanged per cell so
+    // views repaint that row without going through the layoutChanged
+    // invalidation of every persistent QModelIndex.
+    for (int i = 0; i < path.size(); ++i)
+    {
+        const int step = path[i];
+        if (step < 0 || step >= node->children.size())
+            return;
+        node = &node->children[step];
+        const QModelIndex idx = model->index(step, 0, parent);
+        if (!idx.isValid())
+            return;
+        QJsonTreeItem *item = model->itemFromIndex(idx);
+        if (item)
+        {
+            item->setColorType(node->color);
+            item->setIdxRelation(node->relationPath.isEmpty()
+                                     ? QModelIndex()
+                                     : resolveIndex(otherModel,
+                                                    node->relationPath));
+            emit model->dataChanged(
+                idx, model->index(step, last, parent),
+                {Qt::BackgroundRole, Qt::DecorationRole, Qt::DisplayRole});
+        }
+        parent = idx;
+    }
+    // Counter widget listens to dataUpdated for its "N diffs" text.
+    emit model->dataUpdated();
+}
+
 namespace
 {
 
@@ -824,8 +865,15 @@ void linkSubtreesRecursively(DiffNode &a, const QList<int> &aPath,
 //     k > idx) → decrement k by 1 to account for the shift-left.
 void fixupRelationPathsAfterRemoval(DiffNode &otherRoot,
                                     const QList<int> &removedParentPath,
-                                    int removedIdx)
+                                    int removedIdx,
+                                    QList<QList<int>> &orphanPaths)
 {
+    // Track the current path through otherRoot so we can record each
+    // orphan's actual position. removePeer needs those paths to walk
+    // the right ancestor chains on the other side — using the src-side
+    // parentPath was only accurate when the trees lined up index-for-
+    // index, which Phase-B's paired compares can't assume.
+    QList<int> current;
     std::function<void(DiffNode&)> visit = [&](DiffNode &n)
     {
         if (!n.relationPath.isEmpty()
@@ -839,13 +887,19 @@ void fixupRelationPathsAfterRemoval(DiffNode &otherRoot,
             {
                 n.relationPath.clear();
                 n.color = DiffColorType::NotPresent;
+                orphanPaths.append(current);
             }
             else if (k > removedIdx)
             {
                 k = k - 1;
             }
         }
-        for (DiffNode &c : n.children) visit(c);
+        for (int i = 0; i < n.children.size(); ++i)
+        {
+            current.append(i);
+            visit(n.children[i]);
+            current.removeLast();
+        }
     };
     visit(otherRoot);
 }
@@ -1028,9 +1082,11 @@ bool JsonDiffEngine::removePeer(DiffNode &srcRoot, const QList<int> &srcPath,
     parent->children.removeAt(idx);
 
     // Fix peer pointers on the other side: anything pointing into the
-    // removed subtree gets orphaned to NotPresent; anything pointing at
-    // a later sibling slides down by one.
-    fixupRelationPathsAfterRemoval(otherRoot, parentPath, idx);
+    // removed subtree gets orphaned to NotPresent (and its actual path
+    // recorded for ancestor refresh below); anything pointing at a
+    // later sibling slides down by one.
+    QList<QList<int>> orphanPaths;
+    fixupRelationPathsAfterRemoval(otherRoot, parentPath, idx, orphanPaths);
 
     // For arrays, the survivors past `idx` keep their old stringified-
     // index keys ("2","3"…) even though they now sit at positions
@@ -1044,11 +1100,48 @@ bool JsonDiffEngine::removePeer(DiffNode &srcRoot, const QList<int> &srcPath,
             parent->children[i].key = QString::number(i);
     }
 
-    // Refresh ancestor colors on both sides. The removed leaf no
-    // longer exists, but refreshAncestorColors only walks down to its
-    // parent — which still exists.
-    refreshAncestorColors(srcRoot,   srcPath);
-    refreshAncestorColors(otherRoot, parentPath);  // approximate; orphans we already touched
+    // Re-apply the original compareValue rule: paired Object/Array
+    // containers with mismatched child counts BOTH go Huge (matches
+    // main-branch semantics on the next Compare). This is the
+    // edit-time replay of that rule — without it, an Object that
+    // just lost a child while its peer kept everything looked
+    // Identical or Moderate, which the user reads as "no diff" even
+    // though one object is structurally a subset of the other.
+    DiffNode *srcParent = navigateTo(srcRoot, parentPath);
+    DiffNode *dstParent = nullptr;
+    QList<int> dstParentPath;
+    if (srcParent && !srcParent->relationPath.isEmpty())
+    {
+        dstParentPath = srcParent->relationPath;
+        dstParent     = navigateTo(otherRoot, dstParentPath);
+    }
+    const bool isContainerPair = srcParent && dstParent
+            && (srcParent->type == QJsonValue::Object
+                    || srcParent->type == QJsonValue::Array);
+    const bool sizesDiffer = isContainerPair
+            && srcParent->children.size() != dstParent->children.size();
+
+    if (sizesDiffer)
+    {
+        srcParent->color = DiffColorType::Huge;
+        dstParent->color = DiffColorType::Huge;
+    }
+
+    // Refresh ancestors on both sides. The src side walks from
+    // srcPath; the other side from each orphan's actual otherRoot
+    // path (the pre-fix "approximate" walk used src-side indices,
+    // which landed on an unrelated subtree under ParentChildPair).
+    refreshAncestorColors(srcRoot, srcPath);
+    if (sizesDiffer)
+    {
+        // dstParent just changed to Huge — refresh its ancestors
+        // explicitly so they promote to Moderate. refreshAncestorColors
+        // skips Huge nodes themselves, so passing dstParentPath as the
+        // leafPath visits dstParent's ancestors without touching it.
+        refreshAncestorColors(otherRoot, dstParentPath);
+    }
+    for (const QList<int> &p : orphanPaths)
+        refreshAncestorColors(otherRoot, p);
     return true;
 }
 

--- a/jsondiffengine.cpp
+++ b/jsondiffengine.cpp
@@ -20,6 +20,8 @@
 
 #include <QModelIndex>
 #include <QHash>
+#include <QJsonObject>
+#include <QJsonArray>
 #include <functional>
 
 namespace
@@ -37,8 +39,11 @@ class ProgressTracker
 public:
     ProgressTracker(int total,
                     std::atomic<bool> *cancel,
-                    std::function<void(int, int)> onProgress)
-        : mTotal(total), mCancel(cancel), mOnProgress(std::move(onProgress))
+                    std::function<void(int, int)> onProgress,
+                    std::function<void(const QString&)> onPhase = nullptr)
+        : mTotal(total), mCancel(cancel),
+          mOnProgress(std::move(onProgress)),
+          mOnPhase(std::move(onPhase))
     {}
 
     bool tick()
@@ -69,12 +74,20 @@ public:
             mOnProgress(mTotal, mTotal);
     }
 
+    // Announce a new algorithm phase. The host typically rewrites the
+    // dialog label. No-op if no callback was wired in.
+    void setPhase(const QString &name)
+    {
+        if (mOnPhase) mOnPhase(name);
+    }
+
 private:
     int mTotal;
     int mDone = 0;
     int mLastPct = -1;
     std::atomic<bool> *mCancel;
     std::function<void(int, int)> mOnProgress;
+    std::function<void(const QString&)> mOnPhase;
 };
 
 // Count of nodes reachable as children-recursively from `n` (root itself
@@ -261,104 +274,128 @@ bool compareValueOneWay(QList<DiffNode*> &myNodes,
 // ParentChild mode
 // -----------------------------------------------------------------------
 
-// Search the entire right tree for the first node that matches itemLeft's
-// (parent.key, key, type). Same semantics as the original findIndexInModel.
-// Does NOT call tracker->tick() — that happens once per left node at the
-// compareModelsRecursive level — but does check isCancelled() per iter.
-int findInRight(DiffNode &itemLeft,
-                const QList<int> &leftPath,
-                const QString &leftParentKey,
-                DiffNode &right,
-                const QList<int> &rightPath,
-                ProgressTracker *tracker)
+// Pre-built index: (parent.key, child.key) → list of candidates in
+// pre-order DFS, used to replace the original O(N×M) recursive walk
+// over the right tree with O(K) hash lookups (K = candidates per key
+// pair, typically 1).
+struct ParentChildEntry
 {
-    for (int i = 0; i < right.children.size(); ++i)
+    DiffNode  *node;
+    QList<int> path;
+};
+
+// Single QString key joins parent + '\x1F' + child. ASCII Unit
+// Separator can't appear in a parsed JSON key, so no collisions.
+QString indexKey(const QString &parent, const QString &child)
+{
+    return parent + QChar('\x1F') + child;
+}
+
+using FindInRightIndex = QHash<QString, QList<ParentChildEntry>>;
+
+// Walks `node`'s subtree in pre-order DFS, appending each child to the
+// index under (node.key, child.key). Insertion order matches the visit
+// order the original recursive findInRight used, so first-occurrence
+// semantics are preserved bit-for-bit.
+void buildFindInRightIndex(DiffNode &node,
+                           const QList<int> &path,
+                           FindInRightIndex &index)
+{
+    for (int i = 0; i < node.children.size(); ++i)
     {
-        if (tracker && tracker->isCancelled())
-            return -1;
-        DiffNode &candidate = right.children[i];
-        QList<int> candidatePath = rightPath;
-        candidatePath.append(i);
+        DiffNode &child = node.children[i];
+        QList<int> childPath = path;
+        childPath.append(i);
+        index[indexKey(node.key, child.key)]
+            .append({&child, childPath});
+        buildFindInRightIndex(child, childPath, index);
+    }
+}
+
+// Look up the first match for itemLeft in the pre-built index. Returns
+// 0 on match (and writes colour + relationPath on both sides) or -1
+// otherwise. The match logic mirrors the original findInRight branch
+// by branch.
+int findInRightHashed(DiffNode &itemLeft,
+                      const QList<int> &leftPath,
+                      const QString &leftParentKey,
+                      const FindInRightIndex &index,
+                      ProgressTracker *tracker)
+{
+    if (itemLeft.color != DiffColorType::None) return -1;
+    auto it = index.find(indexKey(leftParentKey, itemLeft.key));
+    if (it == index.end()) return -1;
+
+    for (const ParentChildEntry &e : *it)
+    {
+        if (tracker && tracker->isCancelled()) return -1;
+        DiffNode &candidate = *e.node;
+        if (candidate.color != DiffColorType::None) continue;
 
         DiffColorType leftColor  = DiffColorType::Huge;
         DiffColorType rightColor = DiffColorType::Huge;
 
         if (itemLeft.type == candidate.type)
         {
-            if (itemLeft.color == DiffColorType::None
-                    && candidate.color == DiffColorType::None
-                    && leftParentKey == right.key
-                    && itemLeft.key == candidate.key)
+            bool matched = true;
+            if (itemLeft.type == QJsonValue::Array
+                    || itemLeft.type == QJsonValue::Object)
             {
-                bool matched = true;
-                if (itemLeft.type == QJsonValue::Array || itemLeft.type == QJsonValue::Object)
+                if (itemLeft.children.size() == candidate.children.size())
                 {
-                    if (itemLeft.children.size() == candidate.children.size())
-                    {
-                        leftColor  = DiffColorType::Identical;
-                        rightColor = DiffColorType::Identical;
-                    }
+                    leftColor  = DiffColorType::Identical;
+                    rightColor = DiffColorType::Identical;
                 }
-                else if (itemLeft.type == QJsonValue::Double
-                         || itemLeft.type == QJsonValue::String
-                         || itemLeft.type == QJsonValue::Bool)
+            }
+            else if (itemLeft.type == QJsonValue::Double
+                     || itemLeft.type == QJsonValue::String
+                     || itemLeft.type == QJsonValue::Bool)
+            {
+                if (itemLeft.value == candidate.value)
                 {
-                    if (itemLeft.value == candidate.value)
-                    {
-                        leftColor  = DiffColorType::Identical;
-                        rightColor = DiffColorType::Identical;
-                    }
+                    leftColor  = DiffColorType::Identical;
+                    rightColor = DiffColorType::Identical;
                 }
-                else if (itemLeft.type == QJsonValue::Null)
-                {
-                    if (itemLeft.key == candidate.key)
-                    {
-                        leftColor  = DiffColorType::Identical;
-                        rightColor = DiffColorType::Identical;
-                    }
-                }
-                else
-                {
-                    matched = false;
-                }
+            }
+            else if (itemLeft.type == QJsonValue::Null)
+            {
+                // Hash already enforces key match; Null pairs same-keyed
+                // entries as Identical, exactly like the original.
+                leftColor  = DiffColorType::Identical;
+                rightColor = DiffColorType::Identical;
+            }
+            else
+            {
+                // Undefined / unknown types: original walks past without
+                // pairing. Same here.
+                matched = false;
+            }
 
-                if (matched)
-                {
-                    candidate.color = rightColor;
-                    itemLeft.color  = leftColor;
-                    candidate.relationPath = leftPath;
-                    itemLeft.relationPath  = candidatePath;
-                    return 0;
-                }
+            if (matched)
+            {
+                candidate.color = rightColor;
+                itemLeft.color  = leftColor;
+                candidate.relationPath = leftPath;
+                itemLeft.relationPath  = e.path;
+                return 0;
             }
         }
         else
         {
-            // Second-stage match: types differ but parent.key + key match.
-            if (itemLeft.color == DiffColorType::None
-                    && candidate.color == DiffColorType::None
-                    && leftParentKey == right.key
-                    && itemLeft.key == candidate.key)
-            {
-                candidate.color = DiffColorType::Huge;
-                itemLeft.color  = DiffColorType::Huge;
-                candidate.relationPath = leftPath;
-                itemLeft.relationPath  = candidatePath;
-                return 0;
-            }
+            // Type-mismatch fallback: same (parent.key, key), Huge pair.
+            candidate.color = DiffColorType::Huge;
+            itemLeft.color  = DiffColorType::Huge;
+            candidate.relationPath = leftPath;
+            itemLeft.relationPath  = e.path;
+            return 0;
         }
-
-        // Recurse depth-first into the right subtree.
-        int r = findInRight(itemLeft, leftPath, leftParentKey,
-                            candidate, candidatePath, tracker);
-        if (r == 0) return 0;
     }
     return -1;
 }
 
 bool compareModelsRecursive(DiffNode &left,
                             const QList<int> &leftPath,
-                            DiffNode &rightRoot,
+                            const FindInRightIndex &rightIndex,
                             ProgressTracker *tracker)
 {
     for (int i = 0; i < left.children.size(); ++i)
@@ -371,11 +408,11 @@ bool compareModelsRecursive(DiffNode &left,
 
         if (child.color == DiffColorType::None)
         {
-            findInRight(child, childPath, left.key, rightRoot, {}, tracker);
+            findInRightHashed(child, childPath, left.key, rightIndex, tracker);
             if (tracker && tracker->isCancelled())
                 return false;
         }
-        if (!compareModelsRecursive(child, childPath, rightRoot, tracker))
+        if (!compareModelsRecursive(child, childPath, rightIndex, tracker))
             return false;
     }
     return true;
@@ -432,6 +469,19 @@ DiffNode JsonDiffEngine::snapshot(QJsonModel *model)
         root.type = QJsonValue::Object;
     }
     return root;
+}
+
+DiffNode JsonDiffEngine::snapshotIndex(QJsonModel *model, const QModelIndex &idx)
+{
+    DiffNode n;
+    if (!model || !idx.isValid()) return n;
+    QJsonTreeItem *item = model->itemFromIndex(idx);
+    if (!item) return n;
+    n.key   = item->key();
+    n.type  = item->type();
+    n.value = item->value();
+    snapshotChildren(model, idx, n);
+    return n;
 }
 
 namespace
@@ -493,6 +543,7 @@ bool compareInternal(DiffNode &left, DiffNode &right,
 {
     if (mode == JsonDiffEngine::Mode::FullPath)
     {
+        if (tracker) tracker->setPhase(QStringLiteral("Building paths"));
         QStringList                leftPaths;
         QList<DiffNode*>           leftNodes;
         QList<QList<int>>          leftIdxPaths;
@@ -511,6 +562,7 @@ bool compareInternal(DiffNode &left, DiffNode &right,
         const QHash<QString, int> leftIdx  = buildPathIndex(leftPaths);
         const QHash<QString, int> rightIdx = buildPathIndex(rightPaths);
 
+        if (tracker) tracker->setPhase(QStringLiteral("Matching paths"));
         if (!comparePathOneWay(leftNodes,  leftPaths,  leftIdxPaths,
                                rightNodes, rightIdx,   rightIdxPaths, tracker))
             return false;
@@ -518,15 +570,22 @@ bool compareInternal(DiffNode &left, DiffNode &right,
                                leftNodes,  leftIdx,    leftIdxPaths, tracker))
             return false;
 
+        if (tracker) tracker->setPhase(QStringLiteral("Comparing values"));
         if (!compareValueOneWay(leftNodes,  right, tracker)) return false;
         if (!compareValueOneWay(rightNodes, left,  tracker)) return false;
 
+        if (tracker) tracker->setPhase(QStringLiteral("Resolving colours"));
         if (!fixColors(left,  tracker)) return false;
         if (!fixColors(right, tracker)) return false;
     }
     else
     {
-        if (!compareModelsRecursive(left, {}, right, tracker)) return false;
+        if (tracker) tracker->setPhase(QStringLiteral("Indexing right tree"));
+        FindInRightIndex rightIndex;
+        buildFindInRightIndex(right, {}, rightIndex);
+        if (tracker) tracker->setPhase(QStringLiteral("Pairing items"));
+        if (!compareModelsRecursive(left, {}, rightIndex, tracker)) return false;
+        if (tracker) tracker->setPhase(QStringLiteral("Resolving colours"));
         if (!fixColors(left,  tracker)) return false;
         if (!fixColors(right, tracker)) return false;
     }
@@ -557,6 +616,419 @@ void JsonDiffEngine::compare(DiffNode &left, DiffNode &right, Mode mode)
 {
     // Synchronous path: no tracker, no progress, no cancel.
     compareInternal(left, right, mode, nullptr);
+}
+
+// -----------------------------------------------------------------------
+// Phase A — targeted edit-and-recompare
+// -----------------------------------------------------------------------
+
+namespace
+{
+
+// Navigate from `root` along `path` (sequence of child indices).
+// Returns nullptr if any step goes out of bounds. Path may be empty,
+// in which case the root itself is returned.
+DiffNode *navigateTo(DiffNode &root, const QList<int> &path)
+{
+    DiffNode *cur = &root;
+    for (int step : path)
+    {
+        if (step < 0 || step >= cur->children.size())
+            return nullptr;
+        cur = &cur->children[step];
+    }
+    return cur;
+}
+
+// True if a single matched pair (one node per side, already known to
+// reference each other) is "the same" from the algorithm's point of
+// view — mirrors the value/childcount checks compareValueOneWay and
+// findInRight use, so a recomputed colour matches what a full compare
+// would produce for the same pair.
+bool pairLooksIdentical(const DiffNode &L, const DiffNode &R)
+{
+    if (L.type != R.type)
+        return false;
+    if (L.type == QJsonValue::Object || L.type == QJsonValue::Array)
+        return L.children.size() == R.children.size();
+    if (L.type == QJsonValue::Null)
+        return L.key == R.key;  // matches findInRight's Null special case
+    return L.value == R.value;  // scalars (Bool/Double/String)
+}
+
+// After a leaf changed colour, walk from leafPath upward refreshing
+// each ancestor's Moderate/Identical state. The rule mirrors the
+// original fixColors() but adds *demotion*: if all of an ancestor's
+// descendants are now Identical/None/NotPresent, the ancestor can go
+// back to Identical from Moderate. Huge and NotPresent ancestors are
+// not touched (they were set by something other than aggregation).
+void refreshAncestorColors(DiffNode &root, const QList<int> &leafPath)
+{
+    // Collect ancestor pointers from root down to (but not including)
+    // the leaf itself. ancestors[0] is the tree root, ancestors[N-1]
+    // is the leaf's direct parent.
+    QList<DiffNode*> ancestors;
+    DiffNode *cur = &root;
+    ancestors.append(cur);
+    for (int i = 0; i + 1 < leafPath.size(); ++i)
+    {
+        if (leafPath[i] < 0 || leafPath[i] >= cur->children.size())
+            return;
+        cur = &cur->children[leafPath[i]];
+        ancestors.append(cur);
+    }
+
+    // Walk from deepest ancestor up — each level's decision depends on
+    // the level below having already settled.
+    for (int i = ancestors.size() - 1; i >= 0; --i)
+    {
+        DiffNode *node = ancestors[i];
+        if (node->color == DiffColorType::Huge
+                || node->color == DiffColorType::NotPresent)
+            continue;
+
+        bool hasDiffDescendant = false;
+        for (const DiffNode &child : node->children)
+        {
+            if (child.color != DiffColorType::Identical
+                    && child.color != DiffColorType::None
+                    && child.color != DiffColorType::NotPresent)
+            {
+                hasDiffDescendant = true;
+                break;
+            }
+        }
+        node->color = hasDiffDescendant
+            ? DiffColorType::Moderate
+            : DiffColorType::Identical;
+    }
+}
+
+} // anonymous namespace
+
+QJsonValue JsonDiffEngine::toJsonValue(const DiffNode &node)
+{
+    switch (node.type)
+    {
+        case QJsonValue::Object:
+        {
+            QJsonObject obj;
+            for (const DiffNode &c : node.children)
+                obj.insert(c.key, toJsonValue(c));
+            return obj;
+        }
+        case QJsonValue::Array:
+        {
+            QJsonArray arr;
+            for (const DiffNode &c : node.children)
+                arr.append(toJsonValue(c));
+            return arr;
+        }
+        case QJsonValue::String:
+            return QJsonValue(node.value);
+        case QJsonValue::Double:
+            return QJsonValue(node.value.toDouble());
+        case QJsonValue::Bool:
+            return QJsonValue(node.value.compare("true", Qt::CaseInsensitive) == 0);
+        case QJsonValue::Null:
+        case QJsonValue::Undefined:
+        default:
+            return QJsonValue(QJsonValue::Null);
+    }
+}
+
+void JsonDiffEngine::copyPeer(DiffNode &target, const DiffNode &source)
+{
+    // Preserve target.key — it identifies position in target's parent.
+    // colour/relationPath are deliberately untouched; recomparePair()
+    // is the next step the caller will run and it will set them.
+    target.type     = source.type;
+    target.value    = source.value;
+    target.children = source.children;
+}
+
+void JsonDiffEngine::recomparePair(DiffNode &leftRoot,  const QList<int> &leftPath,
+                                   DiffNode &rightRoot, const QList<int> &rightPath,
+                                   Mode mode)
+{
+    Q_UNUSED(mode);  // reserved for mode-specific edge cases (Phase A: not needed)
+
+    DiffNode *L = navigateTo(leftRoot,  leftPath);
+    DiffNode *R = navigateTo(rightRoot, rightPath);
+    if (!L || !R)
+        return;
+
+    const bool identical = pairLooksIdentical(*L, *R);
+    L->color = identical ? DiffColorType::Identical : DiffColorType::Huge;
+    R->color = identical ? DiffColorType::Identical : DiffColorType::Huge;
+
+    refreshAncestorColors(leftRoot,  leftPath);
+    refreshAncestorColors(rightRoot, rightPath);
+}
+
+// -----------------------------------------------------------------------
+// Phase B — append / remove for NotPresent rows
+// -----------------------------------------------------------------------
+
+namespace
+{
+
+// Walk two same-shape subtrees in parallel, marking each pair Identical
+// and mirroring relationPath. Used right after insertPeer's deep-copy
+// so apply() can light up idxRelation across the whole inserted subtree
+// — not just its root.
+void linkSubtreesRecursively(DiffNode &a, const QList<int> &aPath,
+                             DiffNode &b, const QList<int> &bPath)
+{
+    a.color = DiffColorType::Identical;
+    b.color = DiffColorType::Identical;
+    a.relationPath = bPath;
+    b.relationPath = aPath;
+    // copy preserves shape — children sizes match. qMin guards in case
+    // the caller hands us trees that drifted apart somehow.
+    const int n = qMin(a.children.size(), b.children.size());
+    for (int i = 0; i < n; ++i)
+    {
+        QList<int> aChild = aPath; aChild.append(i);
+        QList<int> bChild = bPath; bChild.append(i);
+        linkSubtreesRecursively(a.children[i], aChild, b.children[i], bChild);
+    }
+}
+
+// After srcRoot.children[parentPath][idx] was removed, fix every node
+// in otherRoot whose relationPath either:
+//   - referenced the removed subtree (== parentPath + idx + suffix) →
+//     orphan it: clear relationPath, set color to NotPresent.
+//   - referenced a *later* sibling (parentPath + k + suffix where
+//     k > idx) → decrement k by 1 to account for the shift-left.
+void fixupRelationPathsAfterRemoval(DiffNode &otherRoot,
+                                    const QList<int> &removedParentPath,
+                                    int removedIdx)
+{
+    std::function<void(DiffNode&)> visit = [&](DiffNode &n)
+    {
+        if (!n.relationPath.isEmpty()
+                && n.relationPath.size() > removedParentPath.size()
+                && std::equal(removedParentPath.begin(),
+                              removedParentPath.end(),
+                              n.relationPath.begin()))
+        {
+            int &k = n.relationPath[removedParentPath.size()];
+            if (k == removedIdx)
+            {
+                n.relationPath.clear();
+                n.color = DiffColorType::NotPresent;
+            }
+            else if (k > removedIdx)
+            {
+                k = k - 1;
+            }
+        }
+        for (DiffNode &c : n.children) visit(c);
+    };
+    visit(otherRoot);
+}
+
+} // anonymous namespace
+
+bool JsonDiffEngine::resolveDstParentPath(const DiffNode &srcRoot,
+                                          const QList<int> &srcPath,
+                                          QList<int> &dstParentPath)
+{
+    if (srcPath.isEmpty())
+        return false;                       // can't push root
+    if (srcPath.size() == 1)
+    {
+        // src parent IS the source root → dst parent is the other root.
+        dstParentPath.clear();
+        return true;
+    }
+    // Walk to source parent.
+    const DiffNode *parent = &srcRoot;
+    for (int i = 0; i + 1 < srcPath.size(); ++i)
+    {
+        const int step = srcPath[i];
+        if (step < 0 || step >= parent->children.size())
+            return false;
+        parent = &parent->children[step];
+    }
+    if (parent->relationPath.isEmpty())
+        return false;                       // parent has no peer
+    dstParentPath = parent->relationPath;
+    return true;
+}
+
+QList<int> JsonDiffEngine::insertPeer(DiffNode &srcRoot,
+                                      const QList<int> &srcPath,
+                                      DiffNode &dstRoot,
+                                      const QList<int> &dstParentPath,
+                                      Mode mode)
+{
+    Q_UNUSED(mode);
+
+    DiffNode *src = navigateTo(srcRoot, srcPath);
+    DiffNode *dstParent = navigateTo(dstRoot, dstParentPath);
+    if (!src || !dstParent)
+        return {};
+    if (dstParent->type != QJsonValue::Object
+            && dstParent->type != QJsonValue::Array)
+        return {};
+
+    // Deep-copy the source subtree, then patch the key for the
+    // destination context (arrays index by position, objects keep the
+    // source's key).
+    DiffNode copy = *src;
+    if (dstParent->type == QJsonValue::Array)
+        copy.key = QString::number(dstParent->children.size());
+
+    dstParent->children.append(std::move(copy));
+
+    QList<int> dstPath = dstParentPath;
+    dstPath.append(dstParent->children.size() - 1);
+
+    // Cross-link the whole inserted subtree to its source counterpart
+    // so apply() sets idxRelation everywhere, not just at the root.
+    linkSubtreesRecursively(*src, srcPath,
+                            dstParent->children.last(), dstPath);
+
+    // Refresh both sides' ancestor colours — src's chain may now be
+    // back to Identical (its row went from NotPresent to Identical),
+    // dst's chain may have lost its last diff descendant.
+    refreshAncestorColors(srcRoot, srcPath);
+    refreshAncestorColors(dstRoot, dstPath);
+    return dstPath;
+}
+
+bool JsonDiffEngine::resnapshotSubtree(DiffNode &myRoot,
+                                       const QList<int> &myPath,
+                                       QJsonModel *myModel,
+                                       DiffNode &peerRoot)
+{
+    if (myPath.isEmpty() || !myModel) return false;
+    DiffNode *me = navigateTo(myRoot, myPath);
+    if (!me) return false;
+
+    // Navigate the model to the same path.
+    QModelIndex idx;
+    for (int step : myPath)
+        idx = myModel->index(step, 0, idx);
+    if (!idx.isValid()) return false;
+
+    // Wipe and re-walk children from the model. snapshotChildren is
+    // the same helper snapshot() uses, so the rebuilt subtree mirrors
+    // what a fresh Compare would see.
+    me->children.clear();
+    snapshotChildren(myModel, idx, *me);
+
+    // New children have no peers on the other side — mark the whole
+    // re-snapshotted subtree NotPresent so apply() paints them as
+    // "missing on the other side" until the user re-runs Compare.
+    std::function<void(DiffNode&)> markAllNotPresent = [&](DiffNode &n)
+    {
+        n.color = DiffColorType::NotPresent;
+        n.relationPath.clear();
+        for (DiffNode &c : n.children) markAllNotPresent(c);
+    };
+    for (DiffNode &c : me->children) markAllNotPresent(c);
+
+    // Orphan any peer pointer that referenced something INSIDE the
+    // old subtree. The peer of `me` itself (relationPath == myPath)
+    // is left intact — recomparePair will re-evaluate that pair's
+    // colour after the call returns.
+    std::function<void(DiffNode&)> orphanDescendantPeers = [&](DiffNode &n)
+    {
+        if (!n.relationPath.isEmpty()
+                && n.relationPath.size() > myPath.size()
+                && std::equal(myPath.begin(), myPath.end(),
+                              n.relationPath.begin()))
+        {
+            n.relationPath.clear();
+            n.color = DiffColorType::NotPresent;
+        }
+        for (DiffNode &c : n.children) orphanDescendantPeers(c);
+    };
+    orphanDescendantPeers(peerRoot);
+    return true;
+}
+
+bool JsonDiffEngine::detachPair(DiffNode &myRoot, const QList<int> &myPath,
+                                DiffNode &peerRoot, Mode mode)
+{
+    Q_UNUSED(mode);
+    if (myPath.isEmpty()) return false;
+    DiffNode *me = navigateTo(myRoot, myPath);
+    if (!me) return false;
+
+    const QList<int> peerPath = me->relationPath;
+    me->color = DiffColorType::NotPresent;
+    me->relationPath.clear();
+
+    if (!peerPath.isEmpty())
+    {
+        DiffNode *peer = navigateTo(peerRoot, peerPath);
+        if (peer)
+        {
+            peer->color = DiffColorType::NotPresent;
+            peer->relationPath.clear();
+            refreshAncestorColors(peerRoot, peerPath);
+        }
+    }
+    refreshAncestorColors(myRoot, myPath);
+    return true;
+}
+
+bool JsonDiffEngine::removePeer(DiffNode &srcRoot, const QList<int> &srcPath,
+                                DiffNode &otherRoot, Mode mode)
+{
+    Q_UNUSED(mode);
+
+    if (srcPath.isEmpty())
+        return false;                       // can't remove the root
+
+    // Walk to the source parent and identify the removed index.
+    DiffNode *parent = &srcRoot;
+    for (int i = 0; i + 1 < srcPath.size(); ++i)
+    {
+        const int step = srcPath[i];
+        if (step < 0 || step >= parent->children.size())
+            return false;
+        parent = &parent->children[step];
+    }
+    const int idx = srcPath.last();
+    if (idx < 0 || idx >= parent->children.size())
+        return false;
+
+    QList<int> parentPath = srcPath;
+    parentPath.removeLast();
+
+    // Remove the child. We don't track per-node peer cleanup here —
+    // fixupRelationPathsAfterRemoval does that across the whole other
+    // tree in one walk.
+    parent->children.removeAt(idx);
+
+    // Fix peer pointers on the other side: anything pointing into the
+    // removed subtree gets orphaned to NotPresent; anything pointing at
+    // a later sibling slides down by one.
+    fixupRelationPathsAfterRemoval(otherRoot, parentPath, idx);
+
+    // For arrays, the survivors past `idx` keep their old stringified-
+    // index keys ("2","3"…) even though they now sit at positions
+    // (1, 2, …). QJsonModel::removeRowAt fixes this on the model; the
+    // snapshot must mirror so a subsequent compare uses the same path
+    // strings on both sides (the engine's FullPath matcher includes
+    // keys in the path).
+    if (parent->type == QJsonValue::Array)
+    {
+        for (int i = idx; i < parent->children.size(); ++i)
+            parent->children[i].key = QString::number(i);
+    }
+
+    // Refresh ancestor colours on both sides. The removed leaf no
+    // longer exists, but refreshAncestorColors only walks down to its
+    // parent — which still exists.
+    refreshAncestorColors(srcRoot,   srcPath);
+    refreshAncestorColors(otherRoot, parentPath);  // approximate; orphans we already touched
+    return true;
 }
 
 void JsonDiffEngine::requestCancel()
@@ -602,7 +1074,8 @@ void JsonDiffEngine::compareAsync(QSharedPointer<DiffNode> left,
     ProgressTracker tracker(
         total,
         &mCancelRequested,
-        [this](int done, int t) { emit progressed(done, t); }
+        [this](int done, int t) { emit progressed(done, t); },
+        [this](const QString &phase) { emit phaseChanged(phase); }
     );
 
     // Compute in place on the heap-allocated DiffNodes; no tree copies.

--- a/jsondiffengine.cpp
+++ b/jsondiffengine.cpp
@@ -1,7 +1,7 @@
 /* Author: Yuriy Kuzin
  * Description: implementation of JsonDiffEngine.
  *   Ports the original QJsonDiff comparison algorithm onto DiffNode
- *   trees. Behaviour is preserved exactly — including a couple of
+ *   trees. Behavior is preserved exactly — including a couple of
  *   harmless-by-accident expressions in the original — so the existing
  *   widget tests stay green through this refactor.
  *
@@ -40,7 +40,7 @@ public:
     ProgressTracker(int total,
                     std::atomic<bool> *cancel,
                     std::function<void(int, int)> onProgress,
-                    std::function<void(const QString&)> onPhase = nullptr)
+                    std::function<void(JsonDiffEngine::Phase)> onPhase = nullptr)
         : mTotal(total), mCancel(cancel),
           mOnProgress(std::move(onProgress)),
           mOnPhase(std::move(onPhase))
@@ -76,9 +76,9 @@ public:
 
     // Announce a new algorithm phase. The host typically rewrites the
     // dialog label. No-op if no callback was wired in.
-    void setPhase(const QString &name)
+    void setPhase(JsonDiffEngine::Phase phase)
     {
-        if (mOnPhase) mOnPhase(name);
+        if (mOnPhase) mOnPhase(phase);
     }
 
 private:
@@ -87,7 +87,7 @@ private:
     int mLastPct = -1;
     std::atomic<bool> *mCancel;
     std::function<void(int, int)> mOnProgress;
-    std::function<void(const QString&)> mOnPhase;
+    std::function<void(JsonDiffEngine::Phase)> mOnPhase;
 };
 
 // Count of nodes reachable as children-recursively from `n` (root itself
@@ -313,7 +313,7 @@ void buildFindInRightIndex(DiffNode &node,
 }
 
 // Look up the first match for itemLeft in the pre-built index. Returns
-// 0 on match (and writes colour + relationPath on both sides) or -1
+// 0 on match (and writes color + relationPath on both sides) or -1
 // otherwise. The match logic mirrors the original findInRight branch
 // by branch.
 int findInRightHashed(DiffNode &itemLeft,
@@ -526,9 +526,11 @@ void JsonDiffEngine::apply(const DiffNode &snap, QJsonModel *model, QJsonModel *
 {
     if (!model)
         return;
+    emit model->layoutAboutToBeChanged();
     applyRecursive(snap, model, QModelIndex(), otherModel);
-    // Tell views to repaint — same approach as the original algorithm.
     emit model->layoutChanged();
+    // Counter on the peer container relies on dataUpdated, not layoutChanged.
+    emit model->dataUpdated();
 }
 
 namespace
@@ -543,7 +545,7 @@ bool compareInternal(DiffNode &left, DiffNode &right,
 {
     if (mode == JsonDiffEngine::Mode::FullPath)
     {
-        if (tracker) tracker->setPhase(QStringLiteral("Building paths"));
+        if (tracker) tracker->setPhase(JsonDiffEngine::Phase::BuildingPaths);
         QStringList                leftPaths;
         QList<DiffNode*>           leftNodes;
         QList<QList<int>>          leftIdxPaths;
@@ -562,7 +564,7 @@ bool compareInternal(DiffNode &left, DiffNode &right,
         const QHash<QString, int> leftIdx  = buildPathIndex(leftPaths);
         const QHash<QString, int> rightIdx = buildPathIndex(rightPaths);
 
-        if (tracker) tracker->setPhase(QStringLiteral("Matching paths"));
+        if (tracker) tracker->setPhase(JsonDiffEngine::Phase::MatchingPaths);
         if (!comparePathOneWay(leftNodes,  leftPaths,  leftIdxPaths,
                                rightNodes, rightIdx,   rightIdxPaths, tracker))
             return false;
@@ -570,22 +572,22 @@ bool compareInternal(DiffNode &left, DiffNode &right,
                                leftNodes,  leftIdx,    leftIdxPaths, tracker))
             return false;
 
-        if (tracker) tracker->setPhase(QStringLiteral("Comparing values"));
+        if (tracker) tracker->setPhase(JsonDiffEngine::Phase::ComparingValues);
         if (!compareValueOneWay(leftNodes,  right, tracker)) return false;
         if (!compareValueOneWay(rightNodes, left,  tracker)) return false;
 
-        if (tracker) tracker->setPhase(QStringLiteral("Resolving colours"));
+        if (tracker) tracker->setPhase(JsonDiffEngine::Phase::ResolvingColors);
         if (!fixColors(left,  tracker)) return false;
         if (!fixColors(right, tracker)) return false;
     }
     else
     {
-        if (tracker) tracker->setPhase(QStringLiteral("Indexing right tree"));
+        if (tracker) tracker->setPhase(JsonDiffEngine::Phase::IndexingRightTree);
         FindInRightIndex rightIndex;
         buildFindInRightIndex(right, {}, rightIndex);
-        if (tracker) tracker->setPhase(QStringLiteral("Pairing items"));
+        if (tracker) tracker->setPhase(JsonDiffEngine::Phase::PairingItems);
         if (!compareModelsRecursive(left, {}, rightIndex, tracker)) return false;
-        if (tracker) tracker->setPhase(QStringLiteral("Resolving colours"));
+        if (tracker) tracker->setPhase(JsonDiffEngine::Phase::ResolvingColors);
         if (!fixColors(left,  tracker)) return false;
         if (!fixColors(right, tracker)) return false;
     }
@@ -608,6 +610,7 @@ JsonDiffEngine::JsonDiffEngine(QObject *parent) :
     // marshalling on every Qt version — CI hits "Unable to handle
     // unregistered datatype 'JsonDiffEngine::Mode'" otherwise.
     qRegisterMetaType<JsonDiffEngine::Mode>("JsonDiffEngine::Mode");
+    qRegisterMetaType<JsonDiffEngine::Phase>("JsonDiffEngine::Phase");
 }
 
 JsonDiffEngine::~JsonDiffEngine() = default;
@@ -643,7 +646,7 @@ DiffNode *navigateTo(DiffNode &root, const QList<int> &path)
 // True if a single matched pair (one node per side, already known to
 // reference each other) is "the same" from the algorithm's point of
 // view — mirrors the value/childcount checks compareValueOneWay and
-// findInRight use, so a recomputed colour matches what a full compare
+// findInRight use, so a recomputed color matches what a full compare
 // would produce for the same pair.
 bool pairLooksIdentical(const DiffNode &L, const DiffNode &R)
 {
@@ -656,7 +659,7 @@ bool pairLooksIdentical(const DiffNode &L, const DiffNode &R)
     return L.value == R.value;  // scalars (Bool/Double/String)
 }
 
-// After a leaf changed colour, walk from leafPath upward refreshing
+// After a leaf changed color, walk from leafPath upward refreshing
 // each ancestor's Moderate/Identical state. The rule mirrors the
 // original fixColors() but adds *demotion*: if all of an ancestor's
 // descendants are now Identical/None/NotPresent, the ancestor can go
@@ -729,10 +732,28 @@ QJsonValue JsonDiffEngine::toJsonValue(const DiffNode &node)
         case QJsonValue::Double:
             return QJsonValue(node.value.toDouble());
         case QJsonValue::Bool:
-            return QJsonValue(node.value.compare("true", Qt::CaseInsensitive) == 0);
+        {
+            // Bool snapshots are stringified by QJsonModel as "true" /
+            // "false". Anything else means the snapshot is malformed —
+            // warn so we don't silently coerce garbage to false.
+            const bool isTrue  = node.value.compare(QStringLiteral("true"),
+                                                    Qt::CaseInsensitive) == 0;
+            const bool isFalse = node.value.compare(QStringLiteral("false"),
+                                                    Qt::CaseInsensitive) == 0;
+            if (!isTrue && !isFalse)
+                qWarning() << "JsonDiffEngine::toJsonValue: Bool node has "
+                              "non-canonical value" << node.value
+                           << "— treating as false";
+            return QJsonValue(isTrue);
+        }
         case QJsonValue::Null:
+            return QJsonValue(QJsonValue::Null);
         case QJsonValue::Undefined:
         default:
+            // Undefined should never reach here from a well-formed
+            // snapshot; warn rather than silently substituting Null.
+            qWarning() << "JsonDiffEngine::toJsonValue: unexpected type"
+                       << int(node.type) << "— writing Null";
             return QJsonValue(QJsonValue::Null);
     }
 }
@@ -740,7 +761,7 @@ QJsonValue JsonDiffEngine::toJsonValue(const DiffNode &node)
 void JsonDiffEngine::copyPeer(DiffNode &target, const DiffNode &source)
 {
     // Preserve target.key — it identifies position in target's parent.
-    // colour/relationPath are deliberately untouched; recomparePair()
+    // color/relationPath are deliberately untouched; recomparePair()
     // is the next step the caller will run and it will set them.
     target.type     = source.type;
     target.value    = source.value;
@@ -891,7 +912,7 @@ QList<int> JsonDiffEngine::insertPeer(DiffNode &srcRoot,
     linkSubtreesRecursively(*src, srcPath,
                             dstParent->children.last(), dstPath);
 
-    // Refresh both sides' ancestor colours — src's chain may now be
+    // Refresh both sides' ancestor colors — src's chain may now be
     // back to Identical (its row went from NotPresent to Identical),
     // dst's chain may have lost its last diff descendant.
     refreshAncestorColors(srcRoot, srcPath);
@@ -934,7 +955,7 @@ bool JsonDiffEngine::resnapshotSubtree(DiffNode &myRoot,
     // Orphan any peer pointer that referenced something INSIDE the
     // old subtree. The peer of `me` itself (relationPath == myPath)
     // is left intact — recomparePair will re-evaluate that pair's
-    // colour after the call returns.
+    // color after the call returns.
     std::function<void(DiffNode&)> orphanDescendantPeers = [&](DiffNode &n)
     {
         if (!n.relationPath.isEmpty()
@@ -1023,7 +1044,7 @@ bool JsonDiffEngine::removePeer(DiffNode &srcRoot, const QList<int> &srcPath,
             parent->children[i].key = QString::number(i);
     }
 
-    // Refresh ancestor colours on both sides. The removed leaf no
+    // Refresh ancestor colors on both sides. The removed leaf no
     // longer exists, but refreshAncestorColors only walks down to its
     // parent — which still exists.
     refreshAncestorColors(srcRoot,   srcPath);
@@ -1075,7 +1096,7 @@ void JsonDiffEngine::compareAsync(QSharedPointer<DiffNode> left,
         total,
         &mCancelRequested,
         [this](int done, int t) { emit progressed(done, t); },
-        [this](const QString &phase) { emit phaseChanged(phase); }
+        [this](JsonDiffEngine::Phase phase) { emit phaseChanged(phase); }
     );
 
     // Compute in place on the heap-allocated DiffNodes; no tree copies.

--- a/jsondiffengine.h
+++ b/jsondiffengine.h
@@ -61,6 +61,13 @@ public:
     // Build a snapshot of a model. Main thread only.
     static DiffNode snapshot(QJsonModel *model);
 
+    // Build a DiffNode for one model node (recursively). Used by the
+    // rowsInserted hook in QJsonDiff to splice a newly-dropped subtree
+    // into an existing snapshot without re-walking the whole tree.
+    // Resulting node has no colour/relationPath; caller is expected
+    // to mark it NotPresent (or otherwise) before apply().
+    static DiffNode snapshotIndex(QJsonModel *model, const QModelIndex &idx);
+
     // Push snapshot.color + snapshot.relationPath back onto the model's
     // QJsonTreeItems. Main thread only. Emits layoutChanged() so views
     // repaint.
@@ -71,6 +78,97 @@ public:
     // Fills color + relationPath in place. Used by tests, used as the
     // body of compareAsync(). No thread or signal interaction.
     static void compare(DiffNode &left, DiffNode &right, Mode mode);
+
+    // Convert a snapshot subtree to QJsonValue. Used to hand a peer's
+    // content to QJsonModel::replaceFromJson() without dragging a
+    // DiffNode dependency into qjsonmodel.h.
+    static QJsonValue toJsonValue(const DiffNode &node);
+
+    // --- Phase A: targeted edit-and-recompare ------------------------
+
+    // Copy type/value/children from `source` into `target` in place.
+    // Preserves `target.key` (the key identifies the node's position
+    // in its parent) and does NOT touch color/relationPath — the
+    // caller is expected to follow up with recomparePair() to refresh
+    // colours on the affected pair and their ancestors.
+    static void copyPeer(DiffNode &target, const DiffNode &source);
+
+    // After an edit (or a copyPeer), update the colour of the matched
+    // pair at (leftRoot[leftPath], rightRoot[rightPath]) and walk both
+    // ancestor chains refreshing Moderate / Identical state. Cheap —
+    // no full traversal of either tree. Mode is currently unused but
+    // kept for forward-compatibility with mode-specific edge cases.
+    static void recomparePair(DiffNode &leftRoot,  const QList<int> &leftPath,
+                              DiffNode &rightRoot, const QList<int> &rightPath,
+                              Mode mode);
+
+    // --- Phase B: append / remove for NotPresent rows ----------------
+
+    // Append a copy of `srcRoot[srcPath]` (a NotPresent node) as the
+    // last child of `dstRoot[dstParentPath]`. The inserted subtree is
+    // cross-linked with the source recursively so apply() will set up
+    // idxRelation across every newly-mirrored node — not just the new
+    // root. Refreshes ancestor colours on both sides.
+    //
+    // Append-only (no positional insert): keeps the implementation
+    // simple by avoiding a sibling-relationPath shift. The caller is
+    // expected to mirror this by APPENDING on the model side too.
+    //
+    // Returns the new child's structural path inside dstRoot on success
+    // (so the widget can drive QJsonModel::appendChildFromJson with a
+    // matching position), or an empty list on failure.
+    static QList<int> insertPeer(DiffNode &srcRoot,
+                                 const QList<int> &srcPath,
+                                 DiffNode &dstRoot,
+                                 const QList<int> &dstParentPath,
+                                 Mode mode);
+
+    // Remove the node at `srcRoot[srcPath]`. If that node was paired
+    // (relationPath non-empty), the peer in `otherRoot` is set to
+    // NotPresent and its relationPath cleared — orphaned, the user's
+    // next move is to either push it back or delete it on that side.
+    // Ancestor colours refresh on both sides. Rejects an empty path
+    // (root removal).
+    static bool removePeer(DiffNode &srcRoot, const QList<int> &srcPath,
+                           DiffNode &otherRoot, Mode mode);
+
+    // Detach a paired leaf from its peer: mark both sides NotPresent +
+    // clear cross-links + refresh ancestor colours. Used when a user
+    // renames the key of a paired item — the same slot now names a
+    // different item, so the prior pairing is invalid until the next
+    // Compare. Safe to call with an unpaired node (no-op on the peer
+    // side). Rejects an empty path.
+    static bool detachPair(DiffNode &myRoot, const QList<int> &myPath,
+                           DiffNode &peerRoot, Mode mode);
+
+    // Re-walk the model's subtree at `myPath` and replace the snapshot
+    // subtree's children. The node at myPath KEEPS its key/type/value/
+    // color/relationPath — only children are replaced. New children
+    // default to NotPresent (no peers on the other side yet). Any
+    // node in peerRoot whose relationPath pointed strictly INTO the
+    // old subtree (i.e. relationPath.size() > myPath.size() and starts
+    // with myPath) gets orphaned to NotPresent.
+    //
+    // Used by the inline-edit slot when a column-1 (type) edit
+    // restructures the model's children through Object↔Array
+    // conversion paths — keeps the snapshot consistent without a
+    // full re-Compare. Rejects an empty path (the root has no parent
+    // index to navigate to).
+    static bool resnapshotSubtree(DiffNode &myRoot,
+                                  const QList<int> &myPath,
+                                  QJsonModel *myModel,
+                                  DiffNode &peerRoot);
+
+    // Given a NotPresent node at srcRoot[srcPath], compute the
+    // destination-side parent's structural path in the other tree.
+    // Returns true on success (parent has a peer, or src parent is the
+    // root and we mirror to the other root). The empty parent path =
+    // the other tree's root. Returns false when the source parent is
+    // also NotPresent — the caller should hide the push action in that
+    // case.
+    static bool resolveDstParentPath(const DiffNode &srcRoot,
+                                     const QList<int> &srcPath,
+                                     QList<int> &dstParentPath);
 
     // --- Async cancellation -----------------------------------------
 
@@ -101,6 +199,10 @@ public slots:
 
 signals:
     void progressed(int done, int total);
+    // Emitted at each algorithm-phase boundary so the host can update
+    // the dialog label ("Matching paths…", "Comparing values…", …).
+    // Untranslated; the receiver is expected to map/translate as needed.
+    void phaseChanged(const QString &phase);
     void finished(QSharedPointer<DiffNode> left, QSharedPointer<DiffNode> right);
     void cancelled();
 

--- a/jsondiffengine.h
+++ b/jsondiffengine.h
@@ -53,6 +53,20 @@ public:
     };
     Q_ENUM(Mode)
 
+    // Phase markers for progress reporting. Engine emits the enum;
+    // the host translates it for the user. Engine itself stays free
+    // of UI/translation concerns.
+    enum class Phase
+    {
+        BuildingPaths,      // FullPath: walk both trees, collect paths
+        MatchingPaths,      // FullPath: cross-reference paths via hash
+        ComparingValues,    // FullPath: per-pair value/childCount compare
+        IndexingRightTree,  // ParentChildPair: build hash of right tree
+        PairingItems,       // ParentChildPair: walk left, find peers
+        ResolvingColors    // both modes: ancestor Moderate promotion
+    };
+    Q_ENUM(Phase)
+
     explicit JsonDiffEngine(QObject *parent = nullptr);
     ~JsonDiffEngine() override;
 
@@ -64,7 +78,7 @@ public:
     // Build a DiffNode for one model node (recursively). Used by the
     // rowsInserted hook in QJsonDiff to splice a newly-dropped subtree
     // into an existing snapshot without re-walking the whole tree.
-    // Resulting node has no colour/relationPath; caller is expected
+    // Resulting node has no color/relationPath; caller is expected
     // to mark it NotPresent (or otherwise) before apply().
     static DiffNode snapshotIndex(QJsonModel *model, const QModelIndex &idx);
 
@@ -90,10 +104,10 @@ public:
     // Preserves `target.key` (the key identifies the node's position
     // in its parent) and does NOT touch color/relationPath — the
     // caller is expected to follow up with recomparePair() to refresh
-    // colours on the affected pair and their ancestors.
+    // colors on the affected pair and their ancestors.
     static void copyPeer(DiffNode &target, const DiffNode &source);
 
-    // After an edit (or a copyPeer), update the colour of the matched
+    // After an edit (or a copyPeer), update the color of the matched
     // pair at (leftRoot[leftPath], rightRoot[rightPath]) and walk both
     // ancestor chains refreshing Moderate / Identical state. Cheap —
     // no full traversal of either tree. Mode is currently unused but
@@ -108,7 +122,7 @@ public:
     // last child of `dstRoot[dstParentPath]`. The inserted subtree is
     // cross-linked with the source recursively so apply() will set up
     // idxRelation across every newly-mirrored node — not just the new
-    // root. Refreshes ancestor colours on both sides.
+    // root. Refreshes ancestor colors on both sides.
     //
     // Append-only (no positional insert): keeps the implementation
     // simple by avoiding a sibling-relationPath shift. The caller is
@@ -127,13 +141,13 @@ public:
     // (relationPath non-empty), the peer in `otherRoot` is set to
     // NotPresent and its relationPath cleared — orphaned, the user's
     // next move is to either push it back or delete it on that side.
-    // Ancestor colours refresh on both sides. Rejects an empty path
+    // Ancestor colors refresh on both sides. Rejects an empty path
     // (root removal).
     static bool removePeer(DiffNode &srcRoot, const QList<int> &srcPath,
                            DiffNode &otherRoot, Mode mode);
 
     // Detach a paired leaf from its peer: mark both sides NotPresent +
-    // clear cross-links + refresh ancestor colours. Used when a user
+    // clear cross-links + refresh ancestor colors. Used when a user
     // renames the key of a paired item — the same slot now names a
     // different item, so the prior pairing is invalid until the next
     // Compare. Safe to call with an unpaired node (no-op on the peer
@@ -200,9 +214,10 @@ public slots:
 signals:
     void progressed(int done, int total);
     // Emitted at each algorithm-phase boundary so the host can update
-    // the dialog label ("Matching paths…", "Comparing values…", …).
-    // Untranslated; the receiver is expected to map/translate as needed.
-    void phaseChanged(const QString &phase);
+    // the dialog label. Receiver maps the enum to a tr()'d user-facing
+    // string — engine stays UI-/translation-agnostic. lupdate sees the
+    // tr() calls on the host side.
+    void phaseChanged(JsonDiffEngine::Phase phase);
     void finished(QSharedPointer<DiffNode> left, QSharedPointer<DiffNode> right);
     void cancelled();
 

--- a/jsondiffengine.h
+++ b/jsondiffengine.h
@@ -87,6 +87,17 @@ public:
     // repaint.
     static void apply(const DiffNode &snap, QJsonModel *model, QJsonModel *otherModel);
 
+    // Targeted variant: walk root → `path` (ancestors + the leaf) and
+    // push each node's color + idxRelation. Emits dataChanged for just
+    // those cells rather than layoutChanged, so persistent QModelIndex
+    // remappings and full view-relayout are skipped. Use for inline
+    // edits where only the path (and its ancestor color chain) can
+    // change — value edits, key renames, non-structural recompares.
+    // For structural mutations (type change restructuring children,
+    // inserts, removes) fall back to the full apply().
+    static void applyPath(const DiffNode &snap, QJsonModel *model,
+                          const QList<int> &path, QJsonModel *otherModel);
+
     // --- Synchronous compare (pure compute) --------------------------
 
     // Fills color + relationPath in place. Used by tests, used as the

--- a/jsonitemdelegate.cpp
+++ b/jsonitemdelegate.cpp
@@ -1,5 +1,6 @@
 #include "jsonitemdelegate.h"
 #include "qjsonmodel.h"
+#include "qjsonitem.h"
 #include <QComboBox>
 #include <QDebug>
 
@@ -29,13 +30,16 @@ void JsonItemDelegate::setEditorData(QWidget *editor, const QModelIndex &index) 
     }
 
     QComboBox *comboBox = static_cast<QComboBox*>(editor);
-    // The current value is the item's type name
-    QString currentType = index.model()->data(index, Qt::DisplayRole).toString();
-    // For arrays, the display role is e.g. "Array[5]", so we strip it.
-    if (currentType.startsWith("Array")) {
-        currentType = "Array";
-    }
-    comboBox->setCurrentText(currentType);
+    // Read the item's canonical type name directly instead of parsing
+    // the display string. The model's column-1 DisplayRole is
+    // "Array[N]" for arrays (childcount suffix) and the bare type
+    // name otherwise — using QJsonTreeItem::typeName() side-steps
+    // the parse entirely and stays correct if more types are added.
+    QJsonTreeItem *item = static_cast<QJsonTreeItem*>(index.internalPointer());
+    if (item)
+        comboBox->setCurrentText(item->typeName());
+    else
+        QStyledItemDelegate::setEditorData(editor, index);
 }
 
 void JsonItemDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const

--- a/main.cpp
+++ b/main.cpp
@@ -2,7 +2,9 @@
  */
 #include "mainwindow.h"
 #include "commandlineparser.h"
+#include "preferences/preferences.h"
 #include <QApplication>
+#include <QStyleFactory>
 #include <QTranslator>
 #include <QStandardPaths>
 #include <QFileInfo>
@@ -10,7 +12,7 @@
 #include <QTimer>
 #include <QtDebug>
 
-const QString APP_VERSION = "0.91";
+const QString APP_VERSION = "0.92";
 
 void qtJsonDiffLogger(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
@@ -109,6 +111,13 @@ int main(int argc, char *argv[])
     QApplication::setOrganizationName("ini");
     QApplication::setApplicationName("qtjsondiff");
     QApplication::setApplicationVersion(APP_VERSION);
+
+    // Apply persisted Qt style before any widgets get constructed so
+    // every widget polishes against the right QStyle. Empty pref means
+    // "leave Qt's default alone." setStyle silently no-ops on an
+    // unknown key (e.g. a style the user uninstalled).
+    if (!PREF_INST->appStyle.isEmpty())
+        QApplication::setStyle(PREF_INST->appStyle);
 
     MainWindow w;
     // CLI options

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -21,10 +21,18 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->openLast_action, &QAction::toggled, this, &MainWindow::openLast_action_toggled);
 
     messageJsonCont = new QJsonContainer(ui->jsonview_tab);
-    messageJsonCont->setEditable(true);
+    messageJsonCont->setEditable(PREF_INST->editableSingleTree);
     //messageJsonCont->setBrowseVisible(false);
     messageJsonCont->loadJson(QString("{\"empty\":\"empty\"}"));
     differ = new QJsonDiff(ui->compare_tab);
+    differ->setDiffEditable(PREF_INST->editableDiffView);
+    // Live update: the Preferences dialog toggles checkboxes and emits
+    // editModeChanged so we re-apply without restart.
+    connect(PREF_INST, &Preferences::editModeChanged, this, [this]()
+    {
+        messageJsonCont->setEditable(PREF_INST->editableSingleTree);
+        differ->setDiffEditable(PREF_INST->editableDiffView);
+    });
     QJsonDocument data22 = QJsonDocument::fromJson("{\"empty\":\"empty\"}");
     differ->loadJsonLeft(data22);
     QJsonDocument data11 = QJsonDocument::fromJson("{\"empty\":\"empty\"}");

--- a/preferences/preferences.cpp
+++ b/preferences/preferences.cpp
@@ -64,6 +64,9 @@ void Preferences::load()
     syntaxKeywordColor = s.value("syntax_keyword_color", DEF_SYNTAX_KW_COLOR).value<QColor>();
     syntaxValueColor = s.value("syntax_value_color", DEF_SYNTAX_VAL_COLOR).value<QColor>();
 
+    editableSingleTree = s.value("Edit/single_tree_editable", false).toBool();
+    editableDiffView   = s.value("Edit/diff_view_editable",   false).toBool();
+
     bool needToSaveDefaults = !s.contains("Shortcuts/copy_row");
 
     for (const auto &info : shortcutInfos) {
@@ -102,7 +105,10 @@ void Preferences::save()
 
     s.setValue("syntax_keyword_color", syntaxKeywordColor);
     s.setValue("syntax_value_color", syntaxValueColor);
-    
+
+    s.setValue("Edit/single_tree_editable", editableSingleTree);
+    s.setValue("Edit/diff_view_editable",   editableDiffView);
+
     for (auto it = shortcuts.constBegin(); it != shortcuts.constEnd(); ++it) {
         s.setValue("Shortcuts/" + it.key(), it.value());
         qDebug() << "Saving shortcut for" << it.key() << ":" << it.value().toString();

--- a/preferences/preferences.cpp
+++ b/preferences/preferences.cpp
@@ -67,6 +67,9 @@ void Preferences::load()
     editableSingleTree = s.value("Edit/single_tree_editable", false).toBool();
     editableDiffView   = s.value("Edit/diff_view_editable",   false).toBool();
 
+    appStyle      = s.value("Style/app_style").toString();
+    useStyledTree = s.value("Style/use_styled_tree", false).toBool();
+
     bool needToSaveDefaults = !s.contains("Shortcuts/copy_row");
 
     for (const auto &info : shortcutInfos) {
@@ -108,6 +111,9 @@ void Preferences::save()
 
     s.setValue("Edit/single_tree_editable", editableSingleTree);
     s.setValue("Edit/diff_view_editable",   editableDiffView);
+
+    s.setValue("Style/app_style",        appStyle);
+    s.setValue("Style/use_styled_tree",  useStyledTree);
 
     for (auto it = shortcuts.constBegin(); it != shortcuts.constEnd(); ++it) {
         s.setValue("Shortcuts/" + it.key(), it.value());

--- a/preferences/preferences.h
+++ b/preferences/preferences.h
@@ -68,12 +68,27 @@ public:
     bool editableSingleTree;
     bool editableDiffView;
 
+    // Application QStyle override. Empty string means "don't override"
+    // (let Qt pick its platform default). Requires restart — Qt's
+    // QApplication::setStyle() reparents palettes mid-flight and the
+    // result is uneven across already-built widgets, so we only apply
+    // this in main() before MainWindow is constructed.
+    QString appStyle;
+
+    // Custom tree stylesheet toggle. Off by default — the widget then
+    // looks like the platform's plain QTreeView, matching the
+    // pre-Style-prefs behavior. On, qjsoncontainer applies
+    // qss/qjsontreeview.qss (custom branch icons, hover/select
+    // gradients). Live; flips on styledTreeChanged.
+    bool useStyledTree;
+
     QMap<QString, QKeySequence> shortcuts;
     static const QList<ShortcutInfo> shortcutInfos;
 
 signals:
     void shortcutsUpdated();
     void editModeChanged();
+    void styledTreeChanged();
 
 private:
     explicit Preferences(QObject *parent = nullptr);

--- a/preferences/preferences.h
+++ b/preferences/preferences.h
@@ -62,7 +62,7 @@ public:
     QColor syntaxValueColor;
 
     // Inline-editing toggles. Off by default — integrators that want the
-    // original read-only widget contract see no behaviour change. The
+    // original read-only widget contract see no behavior change. The
     // demo app's MainWindow reads these on startup and re-reads them
     // whenever editModeChanged fires (live update from the dialog).
     bool editableSingleTree;

--- a/preferences/preferences.h
+++ b/preferences/preferences.h
@@ -61,11 +61,19 @@ public:
     QColor syntaxKeywordColor;
     QColor syntaxValueColor;
 
+    // Inline-editing toggles. Off by default — integrators that want the
+    // original read-only widget contract see no behaviour change. The
+    // demo app's MainWindow reads these on startup and re-reads them
+    // whenever editModeChanged fires (live update from the dialog).
+    bool editableSingleTree;
+    bool editableDiffView;
+
     QMap<QString, QKeySequence> shortcuts;
     static const QList<ShortcutInfo> shortcutInfos;
 
 signals:
     void shortcutsUpdated();
+    void editModeChanged();
 
 private:
     explicit Preferences(QObject *parent = nullptr);

--- a/preferences/preferencesdialog.cpp
+++ b/preferences/preferencesdialog.cpp
@@ -63,6 +63,16 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
         PREF_INST->showJsonButtonPosition=-2;
         ui->showJson_buttonGroup->button(-2)->setChecked(true);
     }
+
+    // JSON Editing page — sync checkbox state from current prefs and
+    // route toggles to a single slot that writes the right pref +
+    // notifies listeners (MainWindow re-applies setEditable live).
+    ui->singleTreeEditCheckBox->setChecked(PREF_INST->editableSingleTree);
+    ui->diffViewEditCheckBox->setChecked(PREF_INST->editableDiffView);
+    connect(ui->singleTreeEditCheckBox, &QCheckBox::toggled,
+            this, &PreferencesDialog::editModeCheckBoxToggled);
+    connect(ui->diffViewEditCheckBox,   &QCheckBox::toggled,
+            this, &PreferencesDialog::editModeCheckBoxToggled);
 }
 
 PreferencesDialog::~PreferencesDialog()
@@ -173,6 +183,15 @@ void PreferencesDialog::showJsonButtonPosition_clicked(QAbstractButton* button)
        int id = ui->showJson_buttonGroup->id(button);
        PREF_INST->showJsonButtonPosition=id;
        PREF_INST->save();
+}
+
+void PreferencesDialog::editModeCheckBoxToggled(bool checked)
+{
+    Q_UNUSED(checked);   // we read both checkbox states fresh each time
+    PREF_INST->editableSingleTree = ui->singleTreeEditCheckBox->isChecked();
+    PREF_INST->editableDiffView   = ui->diffViewEditCheckBox->isChecked();
+    PREF_INST->save();
+    emit PREF_INST->editModeChanged();
 }
 
 void PreferencesDialog::shortcut_changed(QStandardItem *item)

--- a/preferences/preferencesdialog.cpp
+++ b/preferences/preferencesdialog.cpp
@@ -2,6 +2,7 @@
 #include <QDebug>
 #include <QHeaderView>
 #include <QShowEvent>
+#include <QStyleFactory>
 
 #include "preferencesdialog.h"
 #include "ui_preferencesdialog.h"
@@ -73,6 +74,26 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
             this, &PreferencesDialog::editModeCheckBoxToggled);
     connect(ui->diffViewEditCheckBox,   &QCheckBox::toggled,
             this, &PreferencesDialog::editModeCheckBoxToggled);
+
+    // Style page — combobox lists every QStyle Qt knows about plus a
+    // "Default" sentinel that means "don't override." We block the
+    // combo's signal while populating so the initial fill doesn't
+    // count as a user pick.
+    ui->appStyleComboBox->blockSignals(true);
+    ui->appStyleComboBox->addItem(tr("Default"), QString());
+    const QStringList styleKeys = QStyleFactory::keys();
+    for (const QString &k : styleKeys)
+        ui->appStyleComboBox->addItem(k, k);
+    const int savedIdx = ui->appStyleComboBox->findData(PREF_INST->appStyle);
+    ui->appStyleComboBox->setCurrentIndex(savedIdx >= 0 ? savedIdx : 0);
+    ui->appStyleComboBox->blockSignals(false);
+    connect(ui->appStyleComboBox,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &PreferencesDialog::appStyleComboBox_currentIndexChanged);
+
+    ui->useStyledTreeCheckBox->setChecked(PREF_INST->useStyledTree);
+    connect(ui->useStyledTreeCheckBox, &QCheckBox::toggled,
+            this, &PreferencesDialog::useStyledTreeCheckBox_toggled);
 }
 
 PreferencesDialog::~PreferencesDialog()
@@ -192,6 +213,19 @@ void PreferencesDialog::editModeCheckBoxToggled(bool checked)
     PREF_INST->editableDiffView   = ui->diffViewEditCheckBox->isChecked();
     PREF_INST->save();
     emit PREF_INST->editModeChanged();
+}
+
+void PreferencesDialog::appStyleComboBox_currentIndexChanged(int index)
+{
+    PREF_INST->appStyle = ui->appStyleComboBox->itemData(index).toString();
+    PREF_INST->save();
+}
+
+void PreferencesDialog::useStyledTreeCheckBox_toggled(bool checked)
+{
+    PREF_INST->useStyledTree = checked;
+    PREF_INST->save();
+    emit PREF_INST->styledTreeChanged();
 }
 
 void PreferencesDialog::shortcut_changed(QStandardItem *item)

--- a/preferences/preferencesdialog.h
+++ b/preferences/preferencesdialog.h
@@ -42,6 +42,7 @@ private slots:
     void tabsPosition_button_clicked(QAbstractButton* button);
     void showJsonButtonPosition_clicked(QAbstractButton* button);
     void shortcut_changed(QStandardItem *item);
+    void editModeCheckBoxToggled(bool checked);
 };
 
 #endif // PREFERENCESDIALOG_H

--- a/preferences/preferencesdialog.h
+++ b/preferences/preferencesdialog.h
@@ -43,6 +43,8 @@ private slots:
     void showJsonButtonPosition_clicked(QAbstractButton* button);
     void shortcut_changed(QStandardItem *item);
     void editModeCheckBoxToggled(bool checked);
+    void appStyleComboBox_currentIndexChanged(int index);
+    void useStyledTreeCheckBox_toggled(bool checked);
 };
 
 #endif // PREFERENCESDIALOG_H

--- a/preferences/preferencesdialog.ui
+++ b/preferences/preferencesdialog.ui
@@ -60,6 +60,14 @@
        </item>
        <item>
         <property name="text">
+         <string>Style</string>
+        </property>
+        <property name="icon">
+         <iconset theme="preferences-desktop-theme"/>
+        </property>
+       </item>
+       <item>
+        <property name="text">
          <string>JSON Editing</string>
         </property>
         <property name="icon">
@@ -409,6 +417,83 @@
                </widget>
               </item>
              </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="stylePage">
+        <layout class="QGridLayout" name="gridLayout_style">
+         <item row="0" column="0">
+          <widget class="QGroupBox" name="styleGroupBox">
+           <property name="title">
+            <string>Style</string>
+           </property>
+           <layout class="QVBoxLayout" name="styleVBox">
+            <item>
+             <layout class="QHBoxLayout" name="appStyleHBox">
+              <item>
+               <widget class="QLabel" name="appStyleLabel">
+                <property name="text">
+                 <string>Application style:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="appStyleComboBox">
+                <property name="toolTip">
+                 <string>Pick the Qt style used by the whole application. &quot;Default&quot; lets Qt choose the platform default.</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="appStyleHSpacer">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QLabel" name="appStyleRestartLabel">
+              <property name="text">
+               <string>Style change takes effect after restart.</string>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">color: gray; font-style: italic;</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="useStyledTreeCheckBox">
+              <property name="text">
+               <string>Use styled tree view</string>
+              </property>
+              <property name="toolTip">
+               <string>When on, JSON tree views get custom branch icons and hover/select gradients from qss/qjsontreeview.qss. Off (default) uses the plain platform look.</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="styleVSpacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </widget>

--- a/preferences/preferencesdialog.ui
+++ b/preferences/preferencesdialog.ui
@@ -60,6 +60,14 @@
        </item>
        <item>
         <property name="text">
+         <string>JSON Editing</string>
+        </property>
+        <property name="icon">
+         <iconset theme="document-edit"/>
+        </property>
+       </item>
+       <item>
+        <property name="text">
          <string>Keyboard Shortcuts</string>
         </property>
         <property name="icon">
@@ -401,6 +409,52 @@
                </widget>
               </item>
              </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="editPage">
+        <layout class="QGridLayout" name="gridLayout_edit">
+         <item row="0" column="0">
+          <widget class="QGroupBox" name="editGroupBox">
+           <property name="title">
+            <string>JSON Editing</string>
+           </property>
+           <layout class="QVBoxLayout" name="editVBox">
+            <item>
+             <widget class="QCheckBox" name="singleTreeEditCheckBox">
+              <property name="text">
+               <string>Enable inline editing in single-tree view</string>
+              </property>
+              <property name="toolTip">
+               <string>When on, keys, types and values can be edited inline on the single-tree tab. Add/Delete row actions also appear in the context menu.</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="diffViewEditCheckBox">
+              <property name="text">
+               <string>Enable inline editing in diff view</string>
+              </property>
+              <property name="toolTip">
+               <string>When on, both diff trees become editable. Push arrows resolve Huge differences and copy NotPresent rows to the other side; Delete here removes the selected row.</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="editVSpacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </widget>

--- a/qjsoncontainer.cpp
+++ b/qjsoncontainer.cpp
@@ -39,6 +39,10 @@ QJsonContainer::QJsonContainer(QWidget *parent):
     myMenu.addSeparator();
     singleExpandSelectedRecursively = myMenu.addAction(expandSelectedRecursively_string);
     singleCollapseSelectedRecursively = myMenu.addAction(collapseSelectedRecursively_string);
+    myMenu.addSeparator();
+    // Edit-mode-only — visibility flipped on/off in showContextMenu.
+    addChildAction  = myMenu.addAction(tr("Add child"));
+    deleteRowAction = myMenu.addAction(tr("Delete row"));
 
     expandSelectedRecursively = multiSelectMenu.addAction(expandSelectedRecursively_string);
     collapseSelectedRecursively = multiSelectMenu.addAction(collapseSelectedRecursively_string);
@@ -471,7 +475,94 @@ void QJsonContainer::on_model_changed()
 
 void QJsonContainer::setEditable(bool editable)
 {
+    mIsEditable = editable;
     model->setEditable(editable);
+
+    // Tree-level item DnD is on iff the model is editable. Both
+    // directions (drag-out, drop-in) are gated together. The file-URL
+    // drop on the surrounding groupbox is untouched — the tree's
+    // default dragEnter handler will ignore MIME types not advertised
+    // by the model (we only advertise our custom type), so file drags
+    // propagate through to the groupbox event filter unchanged.
+    if (editable)
+    {
+        treeview->setDragEnabled(true);
+        treeview->setAcceptDrops(true);
+        treeview->setDropIndicatorShown(true);
+        treeview->setDragDropMode(QAbstractItemView::DragDrop);
+        treeview->setDefaultDropAction(Qt::CopyAction);
+    }
+    else
+    {
+        treeview->setDragEnabled(false);
+        treeview->setAcceptDrops(false);
+        treeview->setDropIndicatorShown(false);
+        treeview->setDragDropMode(QAbstractItemView::NoDragDrop);
+    }
+}
+
+QModelIndex QJsonContainer::addChildOf(const QModelIndex &parent)
+{
+    if (!mIsEditable) return QModelIndex();
+
+    // Invalid parent → root. itemFromIndex returns nullptr for invalid
+    // indexes, so the type / child-count probes go through rootType()
+    // and rowCount() which both treat invalid as root automatically.
+    QJsonValue::Type parentType;
+    if (parent.isValid())
+    {
+        QJsonTreeItem *p = model->itemFromIndex(parent);
+        if (!p) return QModelIndex();
+        parentType = p->type();
+    }
+    else
+    {
+        parentType = model->rootType();
+    }
+    if (parentType != QJsonValue::Object && parentType != QJsonValue::Array)
+        return QModelIndex();
+
+    // Default key. Arrays auto-key by position inside
+    // QJsonModel::appendChildFromJson, so any value works here; objects
+    // need a unique key so we don't immediately collide with a sibling
+    // (QJsonDocument would de-dupe on serialize, hiding the new entry).
+    QString key;
+    if (parentType == QJsonValue::Object)
+    {
+        QSet<QString> used;
+        const int n = model->rowCount(parent);
+        for (int i = 0; i < n; ++i)
+        {
+            QModelIndex childIdx = model->index(i, 0, parent);
+            QJsonTreeItem *c = model->itemFromIndex(childIdx);
+            if (c) used.insert(c->key());
+        }
+        key = "new_key";
+        for (int k = 1; used.contains(key); ++k)
+            key = QString("new_key_%1").arg(k);
+    }
+
+    QModelIndex newIdx = model->appendChildFromJson(parent, key,
+                                                   QJsonValue(QString()));
+    if (!newIdx.isValid()) return newIdx;
+
+    // Surface the new row: expand the parent, select the new child,
+    // start in-place editing on the most useful column.
+    if (parent.isValid())
+        treeview->expand(parent);
+    treeview->setCurrentIndex(newIdx);
+    treeview->scrollTo(newIdx);
+    // Objects: edit the key (so the user names it). Arrays: keys are
+    // positional, jump straight to the value column.
+    const int col = (parentType == QJsonValue::Array) ? 2 : 0;
+    treeview->edit(newIdx.siblingAtColumn(col));
+    return newIdx;
+}
+
+bool QJsonContainer::removeAt(const QModelIndex &target)
+{
+    if (!mIsEditable) return false;
+    return model->removeRowAt(target);
 }
 
 void QJsonContainer::showGoto(bool show)
@@ -555,6 +646,21 @@ void QJsonContainer::showContextMenu(const QPoint &point)
         }
     copyJsonByPath->setEnabled(isContainer);
     copySelectedJsonValuePlain->setEnabled(isContainer);
+
+    // Add/Delete row: shown only in editable mode. "Add child" enables
+    // when the click target is a container (or empty space → root,
+    // which is always a container after loadJson). "Delete row"
+    // enables on any non-root row.
+    if (addChildAction)
+    {
+        addChildAction->setVisible(mIsEditable);
+        addChildAction->setEnabled(!idx.isValid() || isContainer);
+    }
+    if (deleteRowAction)
+    {
+        deleteRowAction->setVisible(mIsEditable);
+        deleteRowAction->setEnabled(idx.isValid() && idx.parent().isValid());
+    }
 
     // for QAbstractScrollArea and derived classes you would use:
     // QPoint globalPos = myWidget->viewport()->mapToGlobal(pos);
@@ -641,6 +747,17 @@ void QJsonContainer::showContextMenu(const QPoint &point)
                             QModelIndex index = selection.at(i);
                             expandRecursively(index, treeview, false);
                         }
+                }
+            else if (selectedItem == addChildAction)
+                {
+                    // Empty-space click resolves to the root container
+                    // via the invalid index → itemFromIndex(QModelIndex())
+                    // path inside addChildOf.
+                    addChildOf(idx);
+                }
+            else if (selectedItem == deleteRowAction)
+                {
+                    removeAt(idx);
                 }
         }
     else

--- a/qjsoncontainer.cpp
+++ b/qjsoncontainer.cpp
@@ -240,16 +240,31 @@ QJsonContainer::QJsonContainer(QWidget *parent):
 
     //treeview->setMinimumSize(500,500);
 
-    //read treeview stylesheet file from app resources
-    QFile file(":/qss/treeview.qss");
-    if (file.open(QIODevice::ReadOnly))
-        {
-            QString styleSheet = file.readAll();
-            file.close();
-            //apply stylesheet to treeview
-            treeview->setStyleSheet(styleSheet);
-        }
-    treeview->ensurePolished();
+    // Optional custom QSS for the tree view. Off by default — matches
+    // the pre-Style-prefs look (plain platform QTreeView). When
+    // Preferences::useStyledTree is on we load qss/qjsontreeview.qss
+    // (custom branch icons + hover/select gradients). Re-applied live
+    // whenever the user flips the checkbox in Preferences.
+    auto applyStyledTree = [this]() {
+        if (PREF_INST->useStyledTree)
+            {
+                QFile file(":/qss/qjsontreeview.qss");
+                if (file.open(QIODevice::ReadOnly))
+                    {
+                        treeview->setStyleSheet(
+                            QString::fromUtf8(file.readAll()));
+                        file.close();
+                    }
+            }
+        else
+            {
+                treeview->setStyleSheet(QString());
+            }
+        treeview->ensurePolished();
+    };
+    applyStyledTree();
+    connect(PREF_INST, &Preferences::styledTreeChanged,
+            this, applyStyledTree);
     treeview->setContextMenuPolicy(Qt::CustomContextMenu);
 
     //some arangments to make drag'n'drop posible

--- a/qjsoncontainer.h
+++ b/qjsoncontainer.h
@@ -83,6 +83,20 @@ public:
     QHBoxLayout *browse_layout;
     void setBrowseVisible(bool state);
     void setEditable(bool editable);
+
+    // Single-tree add/delete (Phase B+ wiring). Public so tests can
+    // exercise them without going through the context menu. Caller
+    // passes the parent (for add) or the target row (for delete).
+    // - addChildOf appends a default String entry to the parent
+    //   (which must be Object or Array). For objects it generates a
+    //   unique "new_key" / "new_key_1" / ... ; for arrays the model
+    //   auto-keys by position. The new row is selected + scrolled to.
+    // - removeAt removes the target row. Rejects root + invalid.
+    // Both no-op when the container is not in editable mode (so
+    // integrators can keep wiring them to shortcuts without checking
+    // edit state themselves).
+    QModelIndex addChildOf(const QModelIndex &parent);
+    bool        removeAt(const QModelIndex &target);
     QPushButton *showjson_pushbutton;
     QAction *findNext_toolbutton;
     QAction *findPrevious_toolbutton;
@@ -127,6 +141,9 @@ private:
     QAction *copySelectedJsonValuePlain;
     QAction *singleExpandSelectedRecursively;
     QAction *singleCollapseSelectedRecursively;
+    QAction *addChildAction = nullptr;       // Phase B+: edit-mode-only
+    QAction *deleteRowAction = nullptr;      // Phase B+: edit-mode-only
+    bool     mIsEditable = false;
     QMenu multiSelectMenu;
     QAction *expandSelected;
     QAction *collapseSelected;

--- a/qjsondiff.cpp
+++ b/qjsondiff.cpp
@@ -1272,6 +1272,13 @@ void QJsonDiff::recomputeAfterUserEdit(const QModelIndex &idx, bool onLeft)
     myNode->type  = modelType;
     myNode->value = modelValue;
 
+    // Track the peer path BEFORE the recompare/detach so we can apply
+    // a targeted refresh on the peer side without walking the whole
+    // peer tree. Value/key edits don't touch structure, so applyPath
+    // is sufficient; type edits restructure children so they fall back
+    // to the full apply.
+    const QList<int> peerPathAtEdit = myNode->relationPath;
+
     if (keyChanged)
     {
         // The renamed slot is no longer "the same item" as before, so
@@ -1293,22 +1300,45 @@ void QJsonDiff::recomputeAfterUserEdit(const QModelIndex &idx, bool onLeft)
         // Type or value drift: same identity, different content →
         // recomparePair lights up Huge on the pair and refreshes
         // ancestor Moderate state on both sides.
-        if (!myNode->relationPath.isEmpty())
+        if (!peerPathAtEdit.isEmpty())
         {
-            const QList<int> peerPath = myNode->relationPath;
             if (onLeft)
                 JsonDiffEngine::recomparePair(*mySnap, myPath,
-                                              *peerSnap, peerPath,
+                                              *peerSnap, peerPathAtEdit,
                                               mLastMode);
             else
-                JsonDiffEngine::recomparePair(*peerSnap, peerPath,
+                JsonDiffEngine::recomparePair(*peerSnap, peerPathAtEdit,
                                               *mySnap, myPath,
                                               mLastMode);
         }
     }
 
-    JsonDiffEngine::apply(*mySnap,   myModel,   peerModel);
-    JsonDiffEngine::apply(*peerSnap, peerModel, myModel);
+    // Type change restructured the subtree — the full apply is needed
+    // so views pick up the new/removed child rows. Value edits and key
+    // renames only shift color+idxRelation along the edited path and
+    // its ancestors, so the targeted applyPath saves the layoutChanged
+    // cost that was making per-edit repaints hitch on ~10k-node trees.
+    if (typeChanged)
+    {
+        JsonDiffEngine::apply(*mySnap,   myModel,   peerModel);
+        JsonDiffEngine::apply(*peerSnap, peerModel, myModel);
+    }
+    else
+    {
+        JsonDiffEngine::applyPath(*mySnap, myModel, myPath, peerModel);
+        if (!peerPathAtEdit.isEmpty())
+            JsonDiffEngine::applyPath(*peerSnap, peerModel,
+                                      peerPathAtEdit, myModel);
+        else if (keyChanged)
+        {
+            // Rename detached the pair — the peer went NotPresent too.
+            // Its color/idxRelation changed but we don't have its path
+            // handy any more (detachPair cleared it). Full apply on
+            // the peer keeps behaviour identical to the pre-fix path;
+            // only fires on rename, which is rare and cheap enough.
+            JsonDiffEngine::apply(*peerSnap, peerModel, myModel);
+        }
+    }
 }
 
 

--- a/qjsondiff.cpp
+++ b/qjsondiff.cpp
@@ -7,6 +7,11 @@
 #include <QTime>
 #include <QThread>
 #include <QProgressDialog>
+#include <QAction>
+#include <QToolBar>
+#include <QItemSelectionModel>
+#include <QStyle>
+#include <QApplication>
 #include "qjsonitem.h"
 #include "jsondiffengine.h"
 #include "preferences/preferences.h"
@@ -113,6 +118,25 @@ QJsonDiff::QJsonDiff(QWidget *parent):
     connect(right_cont,&QJsonContainer::diffSelected,this,&QJsonDiff::on_righttreeview_clicked);
 
     setupCompareWorker();
+    setupPushButtons();
+
+    // Inline-edit live diff refresh. Gated inside the slot on snapshot
+    // presence — pre-Compare edits are ignored. apply() bypasses the
+    // model's setData() path and only fires layoutChanged, so there's
+    // no dataChanged feedback loop from these handlers.
+    connect(left_cont->getJsonModel(),  &QJsonModel::dataChanged,
+            this, &QJsonDiff::onLeftModelDataChanged);
+    connect(right_cont->getJsonModel(), &QJsonModel::dataChanged,
+            this, &QJsonDiff::onRightModelDataChanged);
+
+    // Structural inserts (item DnD between sides, context-menu Add
+    // child) — keep the snapshot in sync so the next diff interaction
+    // sees the new node. The slot marks the inserted subtree gray
+    // (NotPresent) and bumps the drop parent's pair colour if needed.
+    connect(left_cont->getJsonModel(),  &QJsonModel::rowsInserted,
+            this, &QJsonDiff::onLeftRowsInserted);
+    connect(right_cont->getJsonModel(), &QJsonModel::rowsInserted,
+            this, &QJsonDiff::onRightRowsInserted);
 }
 
 QJsonDiff::~QJsonDiff()
@@ -252,6 +276,13 @@ void QJsonDiff::setupCompareWorker()
             this,    &QJsonDiff::onCompareCancelled,  Qt::QueuedConnection);
     connect(mEngine, &JsonDiffEngine::progressed,
             this,    &QJsonDiff::onCompareProgressed, Qt::QueuedConnection);
+    connect(mEngine, &JsonDiffEngine::phaseChanged,
+            this, [this](const QString &phase)
+    {
+        mCurrentPhase = phase;
+        if (mProgressDialog)
+            mProgressDialog->setLabelText(formatProgressLabel());
+    }, Qt::QueuedConnection);
 
     // Note: we deliberately do NOT connect QThread::finished to
     // engine.deleteLater. The worker's event loop has stopped by the
@@ -319,6 +350,7 @@ void QJsonDiff::on_compare_pushbutton_clicked()
     const JsonDiffEngine::Mode mode = useFullPath_checkbox->isChecked()
         ? JsonDiffEngine::Mode::FullPath
         : JsonDiffEngine::Mode::ParentChildPair;
+    mLastMode = mode;
 
     // Modal progress dialog blocks user input until compare completes
     // or is cancelled. Lives until either finished/cancelled fires.
@@ -339,8 +371,15 @@ void QJsonDiff::on_compare_pushbutton_clicked()
             if (mEngine) mEngine->requestCancel();
         });
     }
+    // reset() clears the sticky wasCanceled flag from a prior cancelled
+    // compare — otherwise the setValue(0) below would immediately re-emit
+    // canceled() and abort this run before the engine even starts (D-105).
+    mProgressDialog->reset();
     mProgressDialog->setRange(0, mode == JsonDiffEngine::Mode::FullPath ? 6 : 3);
     mProgressDialog->setValue(0);
+    mCurrentPhase = tr("Starting");
+    mCompareElapsed.start();
+    mProgressDialog->setLabelText(formatProgressLabel());
     mProgressDialog->show();
 
     mEngine->resetCancel();
@@ -369,8 +408,16 @@ void QJsonDiff::onCompareFinished(QSharedPointer<DiffNode> left,
     JsonDiffEngine::apply(*left,  leftModel,  rightModel);
     JsonDiffEngine::apply(*right, rightModel, leftModel);
 
+    // Keep the snapshots alive — Phase A targeted recompare runs on
+    // these without ever rebuilding from the model.
+    mLeftSnap  = left;
+    mRightSnap = right;
+
     left_cont->gotoIndexHandler(true);
     right_cont->gotoIndexHandler(true);
+
+    updateLeftPushAction();
+    updateRightPushAction();
 }
 
 void QJsonDiff::onCompareCancelled()
@@ -380,11 +427,26 @@ void QJsonDiff::onCompareCancelled()
     // Discard partial — no apply (Phase 2 design Q3).
 }
 
+QString QJsonDiff::formatProgressLabel() const
+{
+    const QString phase = mCurrentPhase.isEmpty()
+        ? tr("Running comparison")
+        : mCurrentPhase;
+    if (!mCompareElapsed.isValid())
+        return phase + QStringLiteral("…");
+    const qint64 secs = mCompareElapsed.elapsed() / 1000;
+    return tr("%1… (%2s)").arg(phase).arg(secs);
+}
+
 void QJsonDiff::onCompareProgressed(int done, int total)
 {
     if (!mProgressDialog) return;
     mProgressDialog->setRange(0, total);
     mProgressDialog->setValue(done);
+    // Refresh the label so the elapsed-seconds counter ticks visibly.
+    // The phase string is whatever the last phaseChanged set; the time
+    // is read fresh from mCompareElapsed every tick.
+    mProgressDialog->setLabelText(formatProgressLabel());
 }
 
 void QJsonDiff::startComparison()
@@ -402,11 +464,18 @@ void QJsonDiff::startComparison()
     const JsonDiffEngine::Mode mode = useFullPath_checkbox->isChecked()
         ? JsonDiffEngine::Mode::FullPath
         : JsonDiffEngine::Mode::ParentChildPair;
+    mLastMode = mode;
 
     JsonDiffEngine::compare(leftSnap, rightSnap, mode);
 
     JsonDiffEngine::apply(leftSnap,  leftModel,  rightModel);
     JsonDiffEngine::apply(rightSnap, rightModel, leftModel);
+
+    // Cache snapshots for incremental Phase A edits — store moved copies
+    // on the heap so subsequent recomparePair calls operate on the same
+    // graph the model now reflects.
+    mLeftSnap  = QSharedPointer<DiffNode>::create(std::move(leftSnap));
+    mRightSnap = QSharedPointer<DiffNode>::create(std::move(rightSnap));
 }
 
 void QJsonDiff::setBrowseVisible(bool state)
@@ -503,4 +572,599 @@ void QJsonDiff::showJsonButtonPosition()
     left_cont->showJsonButtonPosition();
     right_cont->showJsonButtonPosition();
 }
+
+// -----------------------------------------------------------------------
+// Phase A — edit-in-diff
+// -----------------------------------------------------------------------
+
+void QJsonDiff::setDiffEditable(bool editable)
+{
+    mDiffEditable = editable;
+    left_cont->setEditable(editable);
+    right_cont->setEditable(editable);
+    updateLeftPushAction();
+    updateRightPushAction();
+    updateLeftDeleteAction();
+    updateRightDeleteAction();
+}
+
+bool QJsonDiff::isDiffEditable() const
+{
+    return mDiffEditable;
+}
+
+void QJsonDiff::setupPushButtons()
+{
+    // Each side gets one "push selected → other side" action, parked
+    // in the side's existing toolbar near the diff counter / prev/next-
+    // diff buttons. Always in the same place, hidden when nothing
+    // meaningful is selected.
+    //
+    // Icons matter: QToolBar's default toolButtonStyle is IconOnly, so
+    // text-only actions render as a blank cell. Use Qt's built-in
+    // standard arrow pixmaps for guaranteed visibility under any style.
+    QStyle *st = QApplication::style();
+
+    mLeftPushAction = new QAction(this);
+    mLeftPushAction->setIcon(st->standardIcon(QStyle::SP_ArrowRight));
+    mLeftPushAction->setText(tr("Push to right"));
+    mLeftPushAction->setToolTip(tr("Push selected row into the matching row on the right side (overwrites)"));
+    mLeftPushAction->setVisible(false);
+    left_cont->toolbar->addAction(mLeftPushAction);
+
+    mRightPushAction = new QAction(this);
+    mRightPushAction->setIcon(st->standardIcon(QStyle::SP_ArrowLeft));
+    mRightPushAction->setText(tr("Push to left"));
+    mRightPushAction->setToolTip(tr("Push selected row into the matching row on the left side (overwrites)"));
+    mRightPushAction->setVisible(false);
+    right_cont->toolbar->addAction(mRightPushAction);
+
+    // Phase B: delete-here actions, parked next to the push actions.
+    mLeftDeleteAction = new QAction(this);
+    mLeftDeleteAction->setIcon(st->standardIcon(QStyle::SP_TrashIcon));
+    mLeftDeleteAction->setText(tr("Delete here"));
+    mLeftDeleteAction->setToolTip(tr("Remove the selected row from this side. If it had a peer on the other side, the peer becomes NotPresent."));
+    mLeftDeleteAction->setVisible(false);
+    left_cont->toolbar->addAction(mLeftDeleteAction);
+
+    mRightDeleteAction = new QAction(this);
+    mRightDeleteAction->setIcon(st->standardIcon(QStyle::SP_TrashIcon));
+    mRightDeleteAction->setText(tr("Delete here"));
+    mRightDeleteAction->setToolTip(tr("Remove the selected row from this side. If it had a peer on the other side, the peer becomes NotPresent."));
+    mRightDeleteAction->setVisible(false);
+    right_cont->toolbar->addAction(mRightDeleteAction);
+
+    connect(mLeftPushAction,  &QAction::triggered,
+            this, &QJsonDiff::pushLeftSelectionToRight);
+    connect(mRightPushAction, &QAction::triggered,
+            this, &QJsonDiff::pushRightSelectionToLeft);
+    connect(mLeftDeleteAction,  &QAction::triggered,
+            this, &QJsonDiff::deleteLeftSelection);
+    connect(mRightDeleteAction, &QAction::triggered,
+            this, &QJsonDiff::deleteRightSelection);
+
+    QTreeView *lv = left_cont->getTreeView();
+    QTreeView *rv = right_cont->getTreeView();
+    connect(lv->selectionModel(), &QItemSelectionModel::currentChanged,
+            this, &QJsonDiff::updateLeftPushAction);
+    connect(rv->selectionModel(), &QItemSelectionModel::currentChanged,
+            this, &QJsonDiff::updateRightPushAction);
+    connect(lv->selectionModel(), &QItemSelectionModel::currentChanged,
+            this, &QJsonDiff::updateLeftDeleteAction);
+    connect(rv->selectionModel(), &QItemSelectionModel::currentChanged,
+            this, &QJsonDiff::updateRightDeleteAction);
+}
+
+void QJsonDiff::updatePushAction(QTreeView *view, QAction *action, QJsonModel *model,
+                                 DiffNode *srcSnapRoot)
+{
+    if (!action || !view || !model) return;
+    // Visibility tracks edit mode. The action's slot is the user-
+    // facing affordance — it shouldn't fade in and out as the cursor
+    // moves between rows. Enabledness reflects whether the current
+    // selection can actually drive a push.
+    action->setVisible(mDiffEditable);
+    if (!mDiffEditable)              { action->setEnabled(false); return; }
+
+    QModelIndex idx = view->currentIndex();
+    if (!idx.isValid())              { action->setEnabled(false); return; }
+    QJsonTreeItem *item = model->itemFromIndex(idx);
+    if (!item)                       { action->setEnabled(false); return; }
+
+    const DiffColorType c = item->colorType();
+
+    // Phase A: Huge with a valid peer → overwrite on the other side.
+    if (c == DiffColorType::Huge && item->idxRelation().isValid())
+    {
+        action->setEnabled(true);
+        return;
+    }
+
+    // Phase B: NotPresent → insert into the matched parent on the
+    // other side, but only when that parent actually has a peer.
+    // Without the resolve check we'd enable the arrow for chained-
+    // missing rows (parent also NotPresent) where the click is a
+    // confirmed no-op. Snapshot may not exist yet before the first
+    // compare — gate on that too.
+    if (c == DiffColorType::NotPresent && srcSnapRoot)
+    {
+        QList<int> dstParentPath;
+        if (JsonDiffEngine::resolveDstParentPath(*srcSnapRoot,
+                                                 indexPath(idx),
+                                                 dstParentPath))
+        {
+            action->setEnabled(true);
+            return;
+        }
+    }
+
+    action->setEnabled(false);
+}
+
+void QJsonDiff::updateLeftPushAction()
+{
+    updatePushAction(left_cont->getTreeView(),
+                     mLeftPushAction,
+                     left_cont->getJsonModel(),
+                     mLeftSnap.data());
+}
+
+void QJsonDiff::updateRightPushAction()
+{
+    updatePushAction(right_cont->getTreeView(),
+                     mRightPushAction,
+                     right_cont->getJsonModel(),
+                     mRightSnap.data());
+}
+
+void QJsonDiff::updateDeleteAction(QTreeView *view, QAction *action)
+{
+    if (!action || !view)            { return; }
+    // Visibility tracks edit mode (matches the push actions). Enabled
+    // tracks whether the selection is a non-root row that the model
+    // can actually remove.
+    action->setVisible(mDiffEditable);
+    if (!mDiffEditable)              { action->setEnabled(false); return; }
+    QModelIndex idx = view->currentIndex();
+    action->setEnabled(idx.isValid() && idx.parent().isValid());
+}
+
+void QJsonDiff::updateLeftDeleteAction()
+{
+    updateDeleteAction(left_cont->getTreeView(), mLeftDeleteAction);
+}
+
+void QJsonDiff::updateRightDeleteAction()
+{
+    updateDeleteAction(right_cont->getTreeView(), mRightDeleteAction);
+}
+
+QList<int> QJsonDiff::indexPath(const QModelIndex &idx)
+{
+    QList<int> path;
+    QModelIndex cur = idx;
+    while (cur.isValid())
+    {
+        path.prepend(cur.row());
+        cur = cur.parent();
+    }
+    return path;
+}
+
+bool QJsonDiff::pushFromTo(QJsonModel *srcModel, const QModelIndex &srcIdx,
+                           QJsonModel *dstModel, const QModelIndex &dstIdx,
+                           DiffNode *srcSnapRoot, DiffNode *dstSnapRoot)
+{
+    if (!srcModel || !dstModel || !srcSnapRoot || !dstSnapRoot)
+        return false;
+    if (!srcIdx.isValid() || !dstIdx.isValid())
+        return false;
+
+    const QList<int> srcPath = indexPath(srcIdx);
+    const QList<int> dstPath = indexPath(dstIdx);
+
+    // 1. Build the JSON value to push from the cached source snapshot.
+    DiffNode *srcNode = nullptr;
+    {
+        DiffNode *cur = srcSnapRoot;
+        for (int step : srcPath)
+        {
+            if (step < 0 || step >= cur->children.size()) return false;
+            cur = &cur->children[step];
+        }
+        srcNode = cur;
+    }
+    DiffNode *dstNode = nullptr;
+    {
+        DiffNode *cur = dstSnapRoot;
+        for (int step : dstPath)
+        {
+            if (step < 0 || step >= cur->children.size()) return false;
+            cur = &cur->children[step];
+        }
+        dstNode = cur;
+    }
+
+    const QJsonValue payload = JsonDiffEngine::toJsonValue(*srcNode);
+
+    // 2. In-place replace on the model — emits dataChanged + dataUpdated,
+    // so the container's find/goto caches reset automatically. Suppress
+    // the rowsInserted hook for the duration: the snapshot bookkeeping
+    // for the new children is done by copyPeer below, not by re-walking
+    // model state.
+    {
+        const bool prev = mSuppressInsertHook;
+        mSuppressInsertHook = true;
+        const bool ok = dstModel->replaceFromJson(dstIdx, payload);
+        mSuppressInsertHook = prev;
+        if (!ok) return false;
+    }
+
+    // 3. Mirror the change on the cached snapshot and re-evaluate the
+    // pair + ancestor chain. No full re-snapshot, no full re-compare.
+    JsonDiffEngine::copyPeer(*dstNode, *srcNode);
+    JsonDiffEngine::recomparePair(*srcSnapRoot, srcPath,
+                                  *dstSnapRoot, dstPath,
+                                  mLastMode);
+
+    // 4. Push colours back onto both models so view repaints with the
+    // updated highlighting.
+    JsonDiffEngine::apply(*srcSnapRoot, srcModel, dstModel);
+    JsonDiffEngine::apply(*dstSnapRoot, dstModel, srcModel);
+
+    // 5. Refresh the push buttons — the row's color just flipped to
+    // Identical, so the action that was visible on it should hide.
+    updateLeftPushAction();
+    updateRightPushAction();
+    updateLeftDeleteAction();
+    updateRightDeleteAction();
+    return true;
+}
+
+bool QJsonDiff::pushInsertFromTo(QJsonModel *srcModel, const QModelIndex &srcIdx,
+                                 QJsonModel *dstModel,
+                                 DiffNode *srcSnapRoot, DiffNode *dstSnapRoot)
+{
+    if (!srcModel || !dstModel || !srcSnapRoot || !dstSnapRoot)
+        return false;
+    if (!srcIdx.isValid())
+        return false;
+
+    const QList<int> srcPath = indexPath(srcIdx);
+
+    // Resolve the destination parent path on the OTHER snapshot via
+    // the source-side parent's relationPath. If the parent isn't paired
+    // (e.g. it's also NotPresent), bail — the user needs to push the
+    // missing parent first.
+    QList<int> dstParentPath;
+    if (!JsonDiffEngine::resolveDstParentPath(*srcSnapRoot, srcPath, dstParentPath))
+        return false;
+
+    // Navigate the destination MODEL to the parent index that matches
+    // dstParentPath. Empty path == invalid index == root.
+    QModelIndex dstParentIdx;
+    for (int step : dstParentPath)
+        dstParentIdx = dstModel->index(step, 0, dstParentIdx);
+
+    // Pull the source DiffNode for payload + key.
+    DiffNode *srcNode = srcSnapRoot;
+    for (int step : srcPath)
+    {
+        if (step < 0 || step >= srcNode->children.size()) return false;
+        srcNode = &srcNode->children[step];
+    }
+    const QJsonValue payload = JsonDiffEngine::toJsonValue(*srcNode);
+
+    // Append on the model. The model picks the new child's key for us
+    // (array parents use the new index; object parents use `key`).
+    // Suppress the rowsInserted hook: insertPeer below installs the
+    // matched-pair Identical + cross-linked snapshot state, which the
+    // hook would otherwise overwrite with a NotPresent placeholder.
+    QModelIndex newIdx;
+    {
+        const bool prev = mSuppressInsertHook;
+        mSuppressInsertHook = true;
+        newIdx = dstModel->appendChildFromJson(dstParentIdx,
+                                              srcNode->key, payload);
+        mSuppressInsertHook = prev;
+    }
+    if (!newIdx.isValid())
+        return false;
+
+    // Mirror on the snapshot. insertPeer cross-links the whole subtree
+    // and refreshes ancestors on both sides.
+    JsonDiffEngine::insertPeer(*srcSnapRoot, srcPath,
+                               *dstSnapRoot, dstParentPath,
+                               mLastMode);
+
+    JsonDiffEngine::apply(*srcSnapRoot, srcModel, dstModel);
+    JsonDiffEngine::apply(*dstSnapRoot, dstModel, srcModel);
+
+    updateLeftPushAction();
+    updateRightPushAction();
+    updateLeftDeleteAction();
+    updateRightDeleteAction();
+    return true;
+}
+
+bool QJsonDiff::deleteOn(QJsonModel *srcModel, const QModelIndex &srcIdx,
+                         QJsonModel *otherModel,
+                         DiffNode *srcSnapRoot, DiffNode *otherSnapRoot)
+{
+    if (!srcModel || !otherModel || !srcSnapRoot || !otherSnapRoot)
+        return false;
+    if (!srcIdx.isValid())
+        return false;
+
+    const QList<int> srcPath = indexPath(srcIdx);
+    if (srcPath.isEmpty()) return false;            // root rejected
+
+    if (!srcModel->removeRowAt(srcIdx))
+        return false;
+
+    JsonDiffEngine::removePeer(*srcSnapRoot, srcPath, *otherSnapRoot, mLastMode);
+
+    JsonDiffEngine::apply(*srcSnapRoot,   srcModel,   otherModel);
+    JsonDiffEngine::apply(*otherSnapRoot, otherModel, srcModel);
+
+    updateLeftPushAction();
+    updateRightPushAction();
+    updateLeftDeleteAction();
+    updateRightDeleteAction();
+    return true;
+}
+
+void QJsonDiff::pushLeftSelectionToRight()
+{
+    if (!mLeftSnap || !mRightSnap) return;
+    QTreeView *lv = left_cont->getTreeView();
+    QJsonModel *lm = left_cont->getJsonModel();
+    QJsonModel *rm = right_cont->getJsonModel();
+    if (!lv || !lm || !rm) return;
+    QModelIndex selIdx = lv->currentIndex();
+    if (!selIdx.isValid()) return;
+    QJsonTreeItem *item = lm->itemFromIndex(selIdx);
+    if (!item) return;
+
+    if (item->colorType() == DiffColorType::NotPresent)
+    {
+        pushInsertFromTo(lm, selIdx, rm,
+                         mLeftSnap.data(), mRightSnap.data());
+        return;
+    }
+    QModelIndex peerIdx = item->idxRelation();
+    if (!peerIdx.isValid()) return;
+    pushFromTo(lm, selIdx, rm, peerIdx,
+               mLeftSnap.data(), mRightSnap.data());
+}
+
+void QJsonDiff::pushRightSelectionToLeft()
+{
+    if (!mLeftSnap || !mRightSnap) return;
+    QTreeView *rv = right_cont->getTreeView();
+    QJsonModel *lm = left_cont->getJsonModel();
+    QJsonModel *rm = right_cont->getJsonModel();
+    if (!rv || !lm || !rm) return;
+    QModelIndex selIdx = rv->currentIndex();
+    if (!selIdx.isValid()) return;
+    QJsonTreeItem *item = rm->itemFromIndex(selIdx);
+    if (!item) return;
+
+    if (item->colorType() == DiffColorType::NotPresent)
+    {
+        pushInsertFromTo(rm, selIdx, lm,
+                         mRightSnap.data(), mLeftSnap.data());
+        return;
+    }
+    QModelIndex peerIdx = item->idxRelation();
+    if (!peerIdx.isValid()) return;
+    pushFromTo(rm, selIdx, lm, peerIdx,
+               mRightSnap.data(), mLeftSnap.data());
+}
+
+void QJsonDiff::deleteLeftSelection()
+{
+    if (!mLeftSnap || !mRightSnap) return;
+    QTreeView *lv = left_cont->getTreeView();
+    QJsonModel *lm = left_cont->getJsonModel();
+    QJsonModel *rm = right_cont->getJsonModel();
+    if (!lv || !lm || !rm) return;
+    deleteOn(lm, lv->currentIndex(), rm,
+             mLeftSnap.data(), mRightSnap.data());
+}
+
+void QJsonDiff::deleteRightSelection()
+{
+    if (!mLeftSnap || !mRightSnap) return;
+    QTreeView *rv = right_cont->getTreeView();
+    QJsonModel *lm = left_cont->getJsonModel();
+    QJsonModel *rm = right_cont->getJsonModel();
+    if (!rv || !lm || !rm) return;
+    deleteOn(rm, rv->currentIndex(), lm,
+             mRightSnap.data(), mLeftSnap.data());
+}
+
+void QJsonDiff::onLeftModelDataChanged(const QModelIndex &topLeft,
+                                       const QModelIndex &bottomRight,
+                                       const QList<int> &roles)
+{
+    Q_UNUSED(bottomRight);
+    Q_UNUSED(roles);
+    recomputeAfterUserEdit(topLeft, /*onLeft=*/true);
+}
+
+void QJsonDiff::onRightModelDataChanged(const QModelIndex &topLeft,
+                                        const QModelIndex &bottomRight,
+                                        const QList<int> &roles)
+{
+    Q_UNUSED(bottomRight);
+    Q_UNUSED(roles);
+    recomputeAfterUserEdit(topLeft, /*onLeft=*/false);
+}
+
+void QJsonDiff::onLeftRowsInserted(const QModelIndex &parent, int first, int last)
+{
+    recomputeAfterRowsInserted(parent, first, last, /*onLeft=*/true);
+}
+
+void QJsonDiff::onRightRowsInserted(const QModelIndex &parent, int first, int last)
+{
+    recomputeAfterRowsInserted(parent, first, last, /*onLeft=*/false);
+}
+
+void QJsonDiff::recomputeAfterRowsInserted(const QModelIndex &parent,
+                                           int first, int last, bool onLeft)
+{
+    if (mSuppressInsertHook) return;          // engine-driven insert
+    if (!mLeftSnap || !mRightSnap) return;   // pre-Compare → nothing to do
+    if (first < 0 || last < first) return;
+
+    DiffNode *mySnap   = onLeft ? mLeftSnap.data()  : mRightSnap.data();
+    DiffNode *peerSnap = onLeft ? mRightSnap.data() : mLeftSnap.data();
+    QJsonModel *myModel   = onLeft ? left_cont->getJsonModel()
+                                   : right_cont->getJsonModel();
+    QJsonModel *peerModel = onLeft ? right_cont->getJsonModel()
+                                   : left_cont->getJsonModel();
+
+    // Path to the drop parent (empty list = root).
+    QList<int> parentPath;
+    if (parent.isValid())
+        parentPath = indexPath(parent.siblingAtColumn(0));
+
+    // Navigate the snapshot to the same node.
+    DiffNode *parentSnap = mySnap;
+    for (int step : parentPath)
+    {
+        if (step < 0 || step >= parentSnap->children.size()) return;
+        parentSnap = &parentSnap->children[step];
+    }
+
+    // Build and splice in a fresh DiffNode for each newly-inserted row,
+    // marking the whole subtree NotPresent (it has no peer on the other
+    // side). Walking [first..last] in order keeps row indices stable as
+    // we insert into parentSnap->children.
+    std::function<void(DiffNode&)> markAllNotPresent = [&](DiffNode &n)
+    {
+        n.color = DiffColorType::NotPresent;
+        n.relationPath.clear();
+        for (DiffNode &c : n.children) markAllNotPresent(c);
+    };
+
+    for (int row = first; row <= last; ++row)
+    {
+        QModelIndex childIdx = myModel->index(row, 0, parent);
+        if (!childIdx.isValid()) return;
+        DiffNode newNode = JsonDiffEngine::snapshotIndex(myModel, childIdx);
+        markAllNotPresent(newNode);
+        // Clamp the insert position — defensive against any future
+        // model that emits rowsInserted with a row past childCount.
+        const int insertAt = qMin(row, int(parentSnap->children.size()));
+        parentSnap->children.insert(insertAt, newNode);
+    }
+
+    // Refresh the drop parent's pair colour if it was matched.
+    // Child counts diverged → pair likely flips to Huge, and ancestors
+    // up to either root get their Moderate state recomputed.
+    // Root case (parentPath empty) skips this: the root has no peer
+    // pairing in the same sense, and there are no ancestors to fix.
+    if (!parentPath.isEmpty() && !parentSnap->relationPath.isEmpty())
+    {
+        const QList<int> peerPath = parentSnap->relationPath;
+        if (onLeft)
+            JsonDiffEngine::recomparePair(*mySnap, parentPath,
+                                          *peerSnap, peerPath,
+                                          mLastMode);
+        else
+            JsonDiffEngine::recomparePair(*peerSnap, peerPath,
+                                          *mySnap, parentPath,
+                                          mLastMode);
+    }
+
+    JsonDiffEngine::apply(*mySnap,   myModel,   peerModel);
+    JsonDiffEngine::apply(*peerSnap, peerModel, myModel);
+}
+
+void QJsonDiff::recomputeAfterUserEdit(const QModelIndex &idx, bool onLeft)
+{
+    if (!mLeftSnap || !mRightSnap) return;   // pre-Compare → nothing to do
+    if (!idx.isValid()) return;
+
+    DiffNode *mySnap   = onLeft ? mLeftSnap.data()  : mRightSnap.data();
+    DiffNode *peerSnap = onLeft ? mRightSnap.data() : mLeftSnap.data();
+    QJsonModel *myModel   = onLeft ? left_cont->getJsonModel()
+                                   : right_cont->getJsonModel();
+    QJsonModel *peerModel = onLeft ? right_cont->getJsonModel()
+                                   : left_cont->getJsonModel();
+
+    // Path uses column-0 sibling so it matches snapshot navigation.
+    const QModelIndex rowIdx = idx.siblingAtColumn(0);
+    const QList<int> myPath = indexPath(rowIdx);
+    if (myPath.isEmpty()) return;            // root has no diff state
+
+    // Navigate to the snapshot node.
+    DiffNode *myNode = mySnap;
+    for (int step : myPath)
+    {
+        if (step < 0 || step >= myNode->children.size()) return;
+        myNode = &myNode->children[step];
+    }
+    QJsonTreeItem *item = myModel->itemFromIndex(rowIdx);
+    if (!item) return;
+
+    const QString modelKey   = item->key();
+    const QJsonValue::Type modelType = item->type();
+    const QString modelValue = item->value();
+
+    const bool keyChanged   = (myNode->key   != modelKey);
+    const bool typeChanged  = (myNode->type  != modelType);
+    const bool valueChanged = (myNode->value != modelValue);
+    if (!keyChanged && !typeChanged && !valueChanged) return;  // engine path already in sync
+
+    // Sync snapshot scalar fields to model. Children get re-walked
+    // below if the type changed — Object↔Array conversion paths
+    // restructure the model's children list and the snapshot has to
+    // catch up so future incremental edits keep working.
+    myNode->key   = modelKey;
+    myNode->type  = modelType;
+    myNode->value = modelValue;
+
+    if (keyChanged)
+    {
+        // The renamed slot is no longer "the same item" as before, so
+        // detach from the peer (both sides go NotPresent). User can
+        // still edit data freely; a fresh Compare re-pairs.
+        JsonDiffEngine::detachPair(*mySnap, myPath, *peerSnap, mLastMode);
+    }
+    else
+    {
+        if (typeChanged)
+        {
+            // Children may have been added/removed by the model's
+            // type-conversion code. Re-walk so the snapshot subtree
+            // matches the model; any peer cross-link pointing INTO
+            // the old subtree gets orphaned.
+            JsonDiffEngine::resnapshotSubtree(*mySnap, myPath, myModel,
+                                              *peerSnap);
+        }
+        // Type or value drift: same identity, different content →
+        // recomparePair lights up Huge on the pair and refreshes
+        // ancestor Moderate state on both sides.
+        if (!myNode->relationPath.isEmpty())
+        {
+            const QList<int> peerPath = myNode->relationPath;
+            if (onLeft)
+                JsonDiffEngine::recomparePair(*mySnap, myPath,
+                                              *peerSnap, peerPath,
+                                              mLastMode);
+            else
+                JsonDiffEngine::recomparePair(*peerSnap, peerPath,
+                                              *mySnap, myPath,
+                                              mLastMode);
+        }
+    }
+
+    JsonDiffEngine::apply(*mySnap,   myModel,   peerModel);
+    JsonDiffEngine::apply(*peerSnap, peerModel, myModel);
+}
+
 

--- a/qjsondiff.cpp
+++ b/qjsondiff.cpp
@@ -3,6 +3,7 @@
  *              side by side comparison of two models
  */
 #include "qjsondiff.h"
+#include <functional>
 #include <QGroupBox>
 #include <QTime>
 #include <QThread>
@@ -132,11 +133,42 @@ QJsonDiff::QJsonDiff(QWidget *parent):
     // Structural inserts (item DnD between sides, context-menu Add
     // child) — keep the snapshot in sync so the next diff interaction
     // sees the new node. The slot marks the inserted subtree gray
-    // (NotPresent) and bumps the drop parent's pair colour if needed.
+    // (NotPresent) and bumps the drop parent's pair color if needed.
     connect(left_cont->getJsonModel(),  &QJsonModel::rowsInserted,
             this, &QJsonDiff::onLeftRowsInserted);
     connect(right_cont->getJsonModel(), &QJsonModel::rowsInserted,
             this, &QJsonDiff::onRightRowsInserted);
+
+    // Structural removes (context-menu Delete, toolbar arrow, any
+    // future path). Clears cross-side idxRelations BEFORE the items
+    // are destroyed, then updates the snapshot in rowsRemoved.
+    connect(left_cont->getJsonModel(),  &QAbstractItemModel::rowsAboutToBeRemoved,
+            this, &QJsonDiff::onLeftRowsAboutToBeRemoved);
+    connect(right_cont->getJsonModel(), &QAbstractItemModel::rowsAboutToBeRemoved,
+            this, &QJsonDiff::onRightRowsAboutToBeRemoved);
+    connect(left_cont->getJsonModel(),  &QAbstractItemModel::rowsRemoved,
+            this, &QJsonDiff::onLeftRowsRemoved);
+    connect(right_cont->getJsonModel(), &QAbstractItemModel::rowsRemoved,
+            this, &QJsonDiff::onRightRowsRemoved);
+
+    // When either side gets a fresh document (loadJson / paste / browse /
+    // URL all go through beginResetModel/endResetModel), the cached diff
+    // snapshots no longer correspond to model state. Drop them both so
+    // subsequent edits don't paint stale colors / idxRelations through
+    // apply(), and the next Compare rebuilds from scratch.
+    auto onSideReset = [this]()
+    {
+        mLeftSnap.reset();
+        mRightSnap.reset();
+        updateLeftPushAction();
+        updateRightPushAction();
+        updateLeftDeleteAction();
+        updateRightDeleteAction();
+    };
+    connect(left_cont->getJsonModel(),  &QAbstractItemModel::modelReset,
+            this, onSideReset);
+    connect(right_cont->getJsonModel(), &QAbstractItemModel::modelReset,
+            this, onSideReset);
 }
 
 QJsonDiff::~QJsonDiff()
@@ -184,8 +216,9 @@ void QJsonDiff::on_lefttreeview_scroll_valuechanged(int val)
         }
     prevLeftScroll=left_cont->getTreeView()->verticalScrollBar()->value();
     prevRightScroll=right_cont->getTreeView()->verticalScrollBar()->value();
-    //right_cont->getTreeView()->repaint();
-    right_cont->getTreeView()->viewport()->repaint();
+    // update() queues a paint event. repaint() runs synchronously and
+    // crashes if called while another paint is in progress on this view.
+    right_cont->getTreeView()->viewport()->update();
     right_cont->getTreeView()->verticalScrollBar()->blockSignals(false);
 
 }
@@ -207,8 +240,7 @@ void QJsonDiff::on_righttreeview_scroll_valuechanged(int val)
         }
     prevLeftScroll=left_cont->getTreeView()->verticalScrollBar()->value();
     prevRightScroll=right_cont->getTreeView()->verticalScrollBar()->value();
-    //left_cont->getTreeView()->repaint();
-    left_cont->getTreeView()->viewport()->repaint();
+    left_cont->getTreeView()->viewport()->update();
     left_cont->getTreeView()->verticalScrollBar()->blockSignals(false);
 }
 
@@ -277,9 +309,25 @@ void QJsonDiff::setupCompareWorker()
     connect(mEngine, &JsonDiffEngine::progressed,
             this,    &QJsonDiff::onCompareProgressed, Qt::QueuedConnection);
     connect(mEngine, &JsonDiffEngine::phaseChanged,
-            this, [this](const QString &phase)
+            this, [this](JsonDiffEngine::Phase phase)
     {
-        mCurrentPhase = phase;
+        // tr() wraps each branch so lupdate picks them up — engine
+        // stays UI-/translation-agnostic.
+        switch (phase)
+        {
+        case JsonDiffEngine::Phase::BuildingPaths:
+            mCurrentPhase = tr("Building paths"); break;
+        case JsonDiffEngine::Phase::MatchingPaths:
+            mCurrentPhase = tr("Matching paths"); break;
+        case JsonDiffEngine::Phase::ComparingValues:
+            mCurrentPhase = tr("Comparing values"); break;
+        case JsonDiffEngine::Phase::IndexingRightTree:
+            mCurrentPhase = tr("Indexing right tree"); break;
+        case JsonDiffEngine::Phase::PairingItems:
+            mCurrentPhase = tr("Pairing items"); break;
+        case JsonDiffEngine::Phase::ResolvingColors:
+            mCurrentPhase = tr("Resolving colors"); break;
+        }
         if (mProgressDialog)
             mProgressDialog->setLabelText(formatProgressLabel());
     }, Qt::QueuedConnection);
@@ -333,7 +381,13 @@ void QJsonDiff::teardownCompareWorker()
 
 void QJsonDiff::on_compare_pushbutton_clicked()
 {
-    qDebug()<<"compare button clicked";
+
+    // Re-entrancy gate: rapid re-click (or ALT+C re-fire) during the
+    // setValue(0) event-pump below would otherwise queue a second
+    // compareAsync and leave the progress dialog desynchronised from
+    // the worker.
+    mComparing = true;
+    compare_pushbutton->setEnabled(false);
 
     left_cont->reInitModel();
     right_cont->reInitModel();
@@ -353,30 +407,32 @@ void QJsonDiff::on_compare_pushbutton_clicked()
     mLastMode = mode;
 
     // Modal progress dialog blocks user input until compare completes
-    // or is cancelled. Lives until either finished/cancelled fires.
+    // or is cancelled. We deliberately CREATE A FRESH DIALOG each compare
+    // — reusing one via reset() + setValue(0) hits QProgressDialog's
+    // internal state machine (shown_once flag, forceTimer interaction)
+    // and can leave the widget painted-but-not-modal when the worker
+    // emits finished() before the show event finishes processing. Fresh
+    // allocation avoids that entire failure mode at zero meaningful cost.
     mCompareCancelledByUser = false;
-    if (!mProgressDialog)
+    if (mProgressDialog)
     {
-        mProgressDialog = new QProgressDialog(this);
-        mProgressDialog->setWindowTitle(tr("Comparing JSON"));
-        mProgressDialog->setLabelText(tr("Running comparison..."));
-        mProgressDialog->setCancelButtonText(tr("Cancel"));
-        mProgressDialog->setWindowModality(Qt::ApplicationModal);
-        mProgressDialog->setAutoClose(false);
-        mProgressDialog->setAutoReset(false);
-        mProgressDialog->setMinimumDuration(0);
-        connect(mProgressDialog, &QProgressDialog::canceled, this, [this]()
-        {
-            mCompareCancelledByUser = true;
-            if (mEngine) mEngine->requestCancel();
-        });
+        mProgressDialog->hide();
+        mProgressDialog->deleteLater();
+        mProgressDialog = nullptr;
     }
-    // reset() clears the sticky wasCanceled flag from a prior cancelled
-    // compare — otherwise the setValue(0) below would immediately re-emit
-    // canceled() and abort this run before the engine even starts (D-105).
-    mProgressDialog->reset();
+    mProgressDialog = new QProgressDialog(this);
+    mProgressDialog->setWindowTitle(tr("Comparing JSON"));
+    mProgressDialog->setCancelButtonText(tr("Cancel"));
+    mProgressDialog->setWindowModality(Qt::ApplicationModal);
+    mProgressDialog->setAutoClose(false);
+    mProgressDialog->setAutoReset(false);
+    mProgressDialog->setMinimumDuration(0);
     mProgressDialog->setRange(0, mode == JsonDiffEngine::Mode::FullPath ? 6 : 3);
-    mProgressDialog->setValue(0);
+    connect(mProgressDialog, &QProgressDialog::canceled, this, [this]()
+    {
+        mCompareCancelledByUser = true;
+        if (mEngine) mEngine->requestCancel();
+    });
     mCurrentPhase = tr("Starting");
     mCompareElapsed.start();
     mProgressDialog->setLabelText(formatProgressLabel());
@@ -393,10 +449,20 @@ void QJsonDiff::onCompareFinished(QSharedPointer<DiffNode> left,
                                   QSharedPointer<DiffNode> right)
 {
     if (mProgressDialog)
+    {
         mProgressDialog->hide();
+        mProgressDialog->deleteLater();
+        mProgressDialog = nullptr;
+    }
+
+    // Release the re-entrancy gate and the visual lock on the Compare
+    // button. Done before any of the early-returns below so the user
+    // can re-Compare even when the result was discarded.
+    mComparing = false;
+    compare_pushbutton->setEnabled(true);
 
     // If the user clicked Cancel just as the engine emitted finished()
-    // (race window), honour the user's intent and discard the result.
+    // (race window), honor the user's intent and discard the result.
     if (mCompareCancelledByUser)
         return;
 
@@ -423,7 +489,13 @@ void QJsonDiff::onCompareFinished(QSharedPointer<DiffNode> left,
 void QJsonDiff::onCompareCancelled()
 {
     if (mProgressDialog)
+    {
         mProgressDialog->hide();
+        mProgressDialog->deleteLater();
+        mProgressDialog = nullptr;
+    }
+    mComparing = false;
+    compare_pushbutton->setEnabled(true);
     // Discard partial — no apply (Phase 2 design Q3).
 }
 
@@ -440,12 +512,15 @@ QString QJsonDiff::formatProgressLabel() const
 
 void QJsonDiff::onCompareProgressed(int done, int total)
 {
+    // setValue() pumps the event loop on a modal dialog. Inside that
+    // pump the queued finished() can drain — onCompareFinished then
+    // deleteLater()s our dialog and the QPointer auto-nulls. Re-check
+    // after every dialog call so we don't touch a destroyed widget.
     if (!mProgressDialog) return;
     mProgressDialog->setRange(0, total);
+    if (!mProgressDialog) return;
     mProgressDialog->setValue(done);
-    // Refresh the label so the elapsed-seconds counter ticks visibly.
-    // The phase string is whatever the last phaseChanged set; the time
-    // is read fresh from mCompareElapsed every tick.
+    if (!mProgressDialog) return;
     mProgressDialog->setLabelText(formatProgressLabel());
 }
 
@@ -807,7 +882,7 @@ bool QJsonDiff::pushFromTo(QJsonModel *srcModel, const QModelIndex &srcIdx,
                                   *dstSnapRoot, dstPath,
                                   mLastMode);
 
-    // 4. Push colours back onto both models so view repaints with the
+    // 4. Push colors back onto both models so view repaints with the
     // updated highlighting.
     JsonDiffEngine::apply(*srcSnapRoot, srcModel, dstModel);
     JsonDiffEngine::apply(*dstSnapRoot, dstModel, srcModel);
@@ -899,13 +974,11 @@ bool QJsonDiff::deleteOn(QJsonModel *srcModel, const QModelIndex &srcIdx,
     const QList<int> srcPath = indexPath(srcIdx);
     if (srcPath.isEmpty()) return false;            // root rejected
 
+    // Peer-side cleanup (clear stale idxRelations + color, snapshot
+    // removePeer + apply for ancestor color refresh) is driven by the
+    // rowsAboutToBeRemoved hook which fires from inside removeRowAt.
     if (!srcModel->removeRowAt(srcIdx))
         return false;
-
-    JsonDiffEngine::removePeer(*srcSnapRoot, srcPath, *otherSnapRoot, mLastMode);
-
-    JsonDiffEngine::apply(*srcSnapRoot,   srcModel,   otherModel);
-    JsonDiffEngine::apply(*otherSnapRoot, otherModel, srcModel);
 
     updateLeftPushAction();
     updateRightPushAction();
@@ -914,74 +987,72 @@ bool QJsonDiff::deleteOn(QJsonModel *srcModel, const QModelIndex &srcIdx,
     return true;
 }
 
-void QJsonDiff::pushLeftSelectionToRight()
+bool QJsonDiff::pushLeftSelectionToRight()
 {
-    if (!mLeftSnap || !mRightSnap) return;
+    if (!mLeftSnap || !mRightSnap) return false;
     QTreeView *lv = left_cont->getTreeView();
     QJsonModel *lm = left_cont->getJsonModel();
     QJsonModel *rm = right_cont->getJsonModel();
-    if (!lv || !lm || !rm) return;
+    if (!lv || !lm || !rm) return false;
     QModelIndex selIdx = lv->currentIndex();
-    if (!selIdx.isValid()) return;
+    if (!selIdx.isValid()) return false;
     QJsonTreeItem *item = lm->itemFromIndex(selIdx);
-    if (!item) return;
+    if (!item) return false;
 
     if (item->colorType() == DiffColorType::NotPresent)
     {
-        pushInsertFromTo(lm, selIdx, rm,
-                         mLeftSnap.data(), mRightSnap.data());
-        return;
+        return pushInsertFromTo(lm, selIdx, rm,
+                                mLeftSnap.data(), mRightSnap.data());
     }
     QModelIndex peerIdx = item->idxRelation();
-    if (!peerIdx.isValid()) return;
-    pushFromTo(lm, selIdx, rm, peerIdx,
-               mLeftSnap.data(), mRightSnap.data());
+    if (!peerIdx.isValid()) return false;
+    return pushFromTo(lm, selIdx, rm, peerIdx,
+                      mLeftSnap.data(), mRightSnap.data());
 }
 
-void QJsonDiff::pushRightSelectionToLeft()
+bool QJsonDiff::pushRightSelectionToLeft()
 {
-    if (!mLeftSnap || !mRightSnap) return;
+    if (!mLeftSnap || !mRightSnap) return false;
     QTreeView *rv = right_cont->getTreeView();
     QJsonModel *lm = left_cont->getJsonModel();
     QJsonModel *rm = right_cont->getJsonModel();
-    if (!rv || !lm || !rm) return;
+    if (!rv || !lm || !rm) return false;
     QModelIndex selIdx = rv->currentIndex();
-    if (!selIdx.isValid()) return;
+    if (!selIdx.isValid()) return false;
     QJsonTreeItem *item = rm->itemFromIndex(selIdx);
-    if (!item) return;
+    if (!item) return false;
 
     if (item->colorType() == DiffColorType::NotPresent)
     {
-        pushInsertFromTo(rm, selIdx, lm,
-                         mRightSnap.data(), mLeftSnap.data());
-        return;
+        return pushInsertFromTo(rm, selIdx, lm,
+                                mRightSnap.data(), mLeftSnap.data());
     }
     QModelIndex peerIdx = item->idxRelation();
-    if (!peerIdx.isValid()) return;
-    pushFromTo(rm, selIdx, lm, peerIdx,
-               mRightSnap.data(), mLeftSnap.data());
+    if (!peerIdx.isValid()) return false;
+    return pushFromTo(rm, selIdx, lm, peerIdx,
+                      mRightSnap.data(), mLeftSnap.data());
 }
 
-void QJsonDiff::deleteLeftSelection()
+bool QJsonDiff::deleteLeftSelection()
 {
-    if (!mLeftSnap || !mRightSnap) return;
+    if (!mLeftSnap || !mRightSnap) return false;
     QTreeView *lv = left_cont->getTreeView();
     QJsonModel *lm = left_cont->getJsonModel();
     QJsonModel *rm = right_cont->getJsonModel();
-    if (!lv || !lm || !rm) return;
-    deleteOn(lm, lv->currentIndex(), rm,
-             mLeftSnap.data(), mRightSnap.data());
+    if (!lv || !lm || !rm) return false;
+    return deleteOn(lm, lv->currentIndex(), rm,
+                    mLeftSnap.data(), mRightSnap.data());
 }
 
-void QJsonDiff::deleteRightSelection()
+bool QJsonDiff::deleteRightSelection()
 {
-    if (!mLeftSnap || !mRightSnap) return;
+    if (!mLeftSnap || !mRightSnap) return false;
     QTreeView *rv = right_cont->getTreeView();
     QJsonModel *lm = left_cont->getJsonModel();
     QJsonModel *rm = right_cont->getJsonModel();
-    if (!rv || !lm || !rm) return;
-    deleteOn(rm, rv->currentIndex(), lm,
-             mRightSnap.data(), mLeftSnap.data());
+    if (!rv || !lm || !rm) return false;
+    return deleteOn(rm, rv->currentIndex(), lm,
+                    mRightSnap.data(), mLeftSnap.data());
 }
 
 void QJsonDiff::onLeftModelDataChanged(const QModelIndex &topLeft,
@@ -1010,6 +1081,79 @@ void QJsonDiff::onLeftRowsInserted(const QModelIndex &parent, int first, int las
 void QJsonDiff::onRightRowsInserted(const QModelIndex &parent, int first, int last)
 {
     recomputeAfterRowsInserted(parent, first, last, /*onLeft=*/false);
+}
+
+static void clearPeerLinksRecursively(QJsonTreeItem *it, QJsonModel *peerModel)
+{
+    if (!it || !peerModel) return;
+    QModelIndex peer = it->idxRelation();
+    if (peer.isValid())
+    {
+        if (QJsonTreeItem *peerItem = peerModel->itemFromIndex(peer))
+        {
+            peerItem->setIdxRelation(QModelIndex());
+            peerItem->setColorType(DiffColorType::NotPresent);
+        }
+    }
+    for (int i = 0; i < it->childCount(); ++i)
+        clearPeerLinksRecursively(it->child(i), peerModel);
+}
+
+void QJsonDiff::onLeftRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last)
+{
+    QJsonModel *srcModel  = left_cont->getJsonModel();
+    QJsonModel *peerModel = right_cont->getJsonModel();
+    for (int row = first; row <= last; ++row)
+    {
+        QModelIndex idx = srcModel->index(row, 0, parent);
+        clearPeerLinksRecursively(srcModel->itemFromIndex(idx), peerModel);
+        if (mLeftSnap && mRightSnap)
+            mPendingRemovedPathsLeft.append(indexPath(idx));
+    }
+}
+
+void QJsonDiff::onRightRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last)
+{
+    QJsonModel *srcModel  = right_cont->getJsonModel();
+    QJsonModel *peerModel = left_cont->getJsonModel();
+    for (int row = first; row <= last; ++row)
+    {
+        QModelIndex idx = srcModel->index(row, 0, parent);
+        clearPeerLinksRecursively(srcModel->itemFromIndex(idx), peerModel);
+        if (mLeftSnap && mRightSnap)
+            mPendingRemovedPathsRight.append(indexPath(idx));
+    }
+}
+
+void QJsonDiff::onLeftRowsRemoved(const QModelIndex &, int, int)
+{
+    if (!mLeftSnap || !mRightSnap) { mPendingRemovedPathsLeft.clear(); return; }
+    // Process descending to avoid index-shift issues within the same parent.
+    std::sort(mPendingRemovedPathsLeft.begin(), mPendingRemovedPathsLeft.end(),
+              std::greater<QList<int>>());
+    for (const QList<int> &p : mPendingRemovedPathsLeft)
+        if (!p.isEmpty())
+            JsonDiffEngine::removePeer(*mLeftSnap, p, *mRightSnap, mLastMode);
+    mPendingRemovedPathsLeft.clear();
+    JsonDiffEngine::apply(*mLeftSnap,  left_cont->getJsonModel(),  right_cont->getJsonModel());
+    JsonDiffEngine::apply(*mRightSnap, right_cont->getJsonModel(), left_cont->getJsonModel());
+    updateLeftPushAction();  updateRightPushAction();
+    updateLeftDeleteAction(); updateRightDeleteAction();
+}
+
+void QJsonDiff::onRightRowsRemoved(const QModelIndex &, int, int)
+{
+    if (!mLeftSnap || !mRightSnap) { mPendingRemovedPathsRight.clear(); return; }
+    std::sort(mPendingRemovedPathsRight.begin(), mPendingRemovedPathsRight.end(),
+              std::greater<QList<int>>());
+    for (const QList<int> &p : mPendingRemovedPathsRight)
+        if (!p.isEmpty())
+            JsonDiffEngine::removePeer(*mRightSnap, p, *mLeftSnap, mLastMode);
+    mPendingRemovedPathsRight.clear();
+    JsonDiffEngine::apply(*mLeftSnap,  left_cont->getJsonModel(),  right_cont->getJsonModel());
+    JsonDiffEngine::apply(*mRightSnap, right_cont->getJsonModel(), left_cont->getJsonModel());
+    updateLeftPushAction();  updateRightPushAction();
+    updateLeftDeleteAction(); updateRightDeleteAction();
 }
 
 void QJsonDiff::recomputeAfterRowsInserted(const QModelIndex &parent,
@@ -1062,7 +1206,7 @@ void QJsonDiff::recomputeAfterRowsInserted(const QModelIndex &parent,
         parentSnap->children.insert(insertAt, newNode);
     }
 
-    // Refresh the drop parent's pair colour if it was matched.
+    // Refresh the drop parent's pair color if it was matched.
     // Child counts diverged → pair likely flips to Huge, and ancestors
     // up to either root get their Moderate state recomputed.
     // Root case (parentPath empty) skips this: the root has no peer

--- a/qjsondiff.h
+++ b/qjsondiff.h
@@ -12,6 +12,7 @@
 #include <QScrollBar>
 #include <QSpacerItem>
 #include <QShortcut>
+#include <QElapsedTimer>
 
 #include "qjsoncontainer.h"
 #include"qjsonitem.h"
@@ -21,6 +22,7 @@
 class QPaintEvent;
 class QThread;
 class QProgressDialog;
+class QAction;
 
 class QJsonDiff : public QWidget
 {
@@ -64,6 +66,13 @@ public:
     void setBrowseVisible(bool state);
     void showJsonButtonPosition();
 
+    // Enable inline diff editing: tree-views become editable and the
+    // overlay "push selected → peer" buttons become available on rows
+    // whose colorType is Huge and whose idxRelation is valid. Off by
+    // default (preserves the read-only contract for integrators).
+    void setDiffEditable(bool editable);
+    bool isDiffEditable() const;
+
 signals:
     void sLoadRightJsonFile(const QString &target);
     void sLoadLeftJsonFile(const QString &target);
@@ -71,6 +80,21 @@ signals:
     void sLeftJsonFileLoaded(const QString &path);
 
 public slots:
+    // Push the value at the currently-selected row on one side INTO
+    // the matching row on the other side. For Huge pairs (Phase A)
+    // overwrites the peer in place. For NotPresent rows (Phase B) the
+    // peer is created on the other side by appending into the matched
+    // parent. Public so integrators can bind them to keyboard
+    // shortcuts; the toolbar arrow buttons trigger these internally.
+    void pushLeftSelectionToRight();
+    void pushRightSelectionToLeft();
+
+    // Phase B: remove the currently-selected row on the corresponding
+    // side. Top-level (root) deletion is rejected. If the row had a
+    // peer on the other side, that peer becomes NotPresent.
+    void deleteLeftSelection();
+    void deleteRightSelection();
+
     void on_compare_pushbutton_clicked();
     void on_lefttreeview_clicked(const QModelIndex&);
     void on_righttreeview_clicked(const QModelIndex&);
@@ -89,6 +113,31 @@ private slots:
     void onCompareCancelled();
     void onCompareProgressed(int done, int total);
 
+    // Refresh push + delete button visibility when the selection changes.
+    void updateLeftPushAction();
+    void updateRightPushAction();
+    void updateLeftDeleteAction();
+    void updateRightDeleteAction();
+
+    // Inline-edit feedback: when user edits a cell on either side,
+    // sync the snapshot and recompare the affected pair so the colour
+    // updates without requiring a full re-compare.
+    void onLeftModelDataChanged(const QModelIndex &topLeft,
+                                const QModelIndex &bottomRight,
+                                const QList<int> &roles);
+    void onRightModelDataChanged(const QModelIndex &topLeft,
+                                 const QModelIndex &bottomRight,
+                                 const QList<int> &roles);
+
+    // Structural-insert feedback for item DnD (and any other
+    // appendChildFromJson / insertChildFromJson caller while the diff
+    // is live). New rows are added to the snapshot as NotPresent
+    // (gray) — they have no peer on the other side. If the drop
+    // parent itself was paired, its colour is refreshed since its
+    // child count diverged.
+    void onLeftRowsInserted(const QModelIndex &parent, int first, int last);
+    void onRightRowsInserted(const QModelIndex &parent, int first, int last);
+
 protected:
     void paintEvent(QPaintEvent *) override;
 
@@ -100,9 +149,64 @@ private:
     QThread         *mWorkerThread = nullptr;
     QProgressDialog *mProgressDialog = nullptr;
     bool             mCompareCancelledByUser = false;
+    QElapsedTimer    mCompareElapsed;             // Phase 3 polish
+    QString          mCurrentPhase;               // last phaseChanged emission
 
     void setupCompareWorker();
     void teardownCompareWorker();
+    // Builds the progress-dialog label from mCurrentPhase + the
+    // elapsed time on mCompareElapsed. "Comparing values… (12s)" etc.
+    QString formatProgressLabel() const;
+    // Common back-half for both dataChanged slots: walk to the snapshot
+    // node at the changed model index, mirror key/type/value, then run
+    // the appropriate engine helper (recomparePair for content drift,
+    // detachPair for a key rename) and re-apply to both models.
+    void recomputeAfterUserEdit(const QModelIndex &idx, bool onLeft);
+
+    // Back-half for both rowsInserted slots: build a fresh DiffNode
+    // for each new model row, mark it NotPresent, splice into the
+    // parent snapshot at the correct position, then refresh the
+    // parent pair if it was matched and re-apply both snapshots.
+    void recomputeAfterRowsInserted(const QModelIndex &parent,
+                                    int first, int last, bool onLeft);
+
+    // Phase A — edit-in-diff state.
+    bool                       mDiffEditable = false;
+    // Re-entrancy guard for the rowsInserted snapshot hook. Set true
+    // while pushFromTo / pushInsertFromTo do their own snapshot
+    // bookkeeping (insertPeer / copyPeer) — without this flag the
+    // model-side appendChildFromJson / replaceFromJson would trigger
+    // onLeftRowsInserted / onRightRowsInserted and double-splice
+    // (or splice a NotPresent placeholder that fights the
+    // cross-linked Identical state insertPeer just set up).
+    bool                       mSuppressInsertHook = false;
+    QAction                   *mLeftPushAction    = nullptr;   // in left toolbar
+    QAction                   *mRightPushAction   = nullptr;   // in right toolbar
+    QAction                   *mLeftDeleteAction  = nullptr;   // Phase B
+    QAction                   *mRightDeleteAction = nullptr;   // Phase B
+    QSharedPointer<DiffNode>   mLeftSnap;       // kept alive after a compare
+    QSharedPointer<DiffNode>   mRightSnap;      // for targeted recompare on edit
+    JsonDiffEngine::Mode       mLastMode = JsonDiffEngine::Mode::FullPath;
+
+    void setupPushButtons();
+    void updatePushAction(QTreeView *view, QAction *action, QJsonModel *model,
+                         DiffNode *srcSnapRoot);
+    void updateDeleteAction(QTreeView *view, QAction *action);
+    static QList<int> indexPath(const QModelIndex &idx);
+    bool pushFromTo(QJsonModel *srcModel, const QModelIndex &srcIdx,
+                    QJsonModel *dstModel, const QModelIndex &dstIdx,
+                    DiffNode *srcSnapRoot, DiffNode *dstSnapRoot);
+    // Phase B variants. pushInsertFromTo handles the NotPresent path:
+    // walks up the source snapshot to find the matched parent on the
+    // destination side, calls JsonDiffEngine::insertPeer + the model's
+    // appendChildFromJson. deleteOn handles single-side removal +
+    // peer-orphan + recompare.
+    bool pushInsertFromTo(QJsonModel *srcModel, const QModelIndex &srcIdx,
+                          QJsonModel *dstModel,
+                          DiffNode *srcSnapRoot, DiffNode *dstSnapRoot);
+    bool deleteOn(QJsonModel *srcModel, const QModelIndex &srcIdx,
+                  QJsonModel *otherModel,
+                  DiffNode *srcSnapRoot, DiffNode *otherSnapRoot);
 };
 
 #endif // QJSONDIFF_H

--- a/qjsondiff.h
+++ b/qjsondiff.h
@@ -13,6 +13,7 @@
 #include <QSpacerItem>
 #include <QShortcut>
 #include <QElapsedTimer>
+#include <QPointer>
 
 #include "qjsoncontainer.h"
 #include"qjsonitem.h"
@@ -86,14 +87,19 @@ public slots:
     // peer is created on the other side by appending into the matched
     // parent. Public so integrators can bind them to keyboard
     // shortcuts; the toolbar arrow buttons trigger these internally.
-    void pushLeftSelectionToRight();
-    void pushRightSelectionToLeft();
+    // Returns true on success, false when nothing was done (pre-Compare,
+    // no selection, root, chained-missing peer). Queued-connection
+    // callers can ignore the return; direct callers can use it to know
+    // whether to update their own UI.
+    bool pushLeftSelectionToRight();
+    bool pushRightSelectionToLeft();
 
     // Phase B: remove the currently-selected row on the corresponding
     // side. Top-level (root) deletion is rejected. If the row had a
-    // peer on the other side, that peer becomes NotPresent.
-    void deleteLeftSelection();
-    void deleteRightSelection();
+    // peer on the other side, that peer becomes NotPresent. Returns
+    // true on success, false on rejected/no-op.
+    bool deleteLeftSelection();
+    bool deleteRightSelection();
 
     void on_compare_pushbutton_clicked();
     void on_lefttreeview_clicked(const QModelIndex&);
@@ -120,7 +126,7 @@ private slots:
     void updateRightDeleteAction();
 
     // Inline-edit feedback: when user edits a cell on either side,
-    // sync the snapshot and recompare the affected pair so the colour
+    // sync the snapshot and recompare the affected pair so the color
     // updates without requiring a full re-compare.
     void onLeftModelDataChanged(const QModelIndex &topLeft,
                                 const QModelIndex &bottomRight,
@@ -133,10 +139,17 @@ private slots:
     // appendChildFromJson / insertChildFromJson caller while the diff
     // is live). New rows are added to the snapshot as NotPresent
     // (gray) — they have no peer on the other side. If the drop
-    // parent itself was paired, its colour is refreshed since its
+    // parent itself was paired, its color is refreshed since its
     // child count diverged.
     void onLeftRowsInserted(const QModelIndex &parent, int first, int last);
     void onRightRowsInserted(const QModelIndex &parent, int first, int last);
+
+    // Fires from inside removeRowAt before the items are destroyed.
+    // Handles any delete path (context-menu, toolbar arrow, ...).
+    void onLeftRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last);
+    void onRightRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last);
+    void onLeftRowsRemoved(const QModelIndex &parent, int first, int last);
+    void onRightRowsRemoved(const QModelIndex &parent, int first, int last);
 
 protected:
     void paintEvent(QPaintEvent *) override;
@@ -147,8 +160,21 @@ private:
     // not touch these.
     JsonDiffEngine  *mEngine = nullptr;
     QThread         *mWorkerThread = nullptr;
-    QProgressDialog *mProgressDialog = nullptr;
+    // QPointer auto-nulls when the dialog is destroyed. Needed because
+    // QProgressDialog::setValue() pumps the event loop on a modal dialog,
+    // and the queued finished() can drain mid-pump, calling deleteLater
+    // on this dialog — the in-flight onCompareProgressed must observe
+    // the null and bail before its next dialog method call.
+    QPointer<QProgressDialog> mProgressDialog;
     bool             mCompareCancelledByUser = false;
+    // Re-entrancy guard against rapid re-click on the Compare button (or
+    // the ALT+C shortcut) while a previous compare is still in flight.
+    // Without it, QProgressDialog::setValue() pumps the event loop on a
+    // modal dialog before show() runs — that pump can deliver a queued
+    // second click, re-enter on_compare_pushbutton_clicked, queue a
+    // second compareAsync, and leave the dialog in a state where finished
+    // arrives before the second show() and the dialog hangs visible.
+    bool             mComparing = false;
     QElapsedTimer    mCompareElapsed;             // Phase 3 polish
     QString          mCurrentPhase;               // last phaseChanged emission
 
@@ -180,6 +206,10 @@ private:
     // (or splice a NotPresent placeholder that fights the
     // cross-linked Identical state insertPeer just set up).
     bool                       mSuppressInsertHook = false;
+    // Paths captured in rowsAboutToBeRemoved (model still has rows),
+    // consumed in rowsRemoved (model gone) for the snapshot update.
+    QList<QList<int>>          mPendingRemovedPathsLeft;
+    QList<QList<int>>          mPendingRemovedPathsRight;
     QAction                   *mLeftPushAction    = nullptr;   // in left toolbar
     QAction                   *mRightPushAction   = nullptr;   // in right toolbar
     QAction                   *mLeftDeleteAction  = nullptr;   // Phase B

--- a/qjsonitem.cpp
+++ b/qjsonitem.cpp
@@ -73,6 +73,22 @@ void QJsonTreeItem::appendChild(QJsonTreeItem *item)
     mChilds.append(item);
 }
 
+void QJsonTreeItem::insertChild(int row, QJsonTreeItem *item)
+{
+    if (!item) return;
+    if (row < 0) row = 0;
+    if (row > mChilds.size()) row = mChilds.size();
+    item->setParent(this);
+    mChilds.insert(row, item);
+}
+
+QJsonTreeItem *QJsonTreeItem::takeChildAt(int row)
+{
+    if (row < 0 || row >= mChilds.size())
+        return nullptr;
+    return mChilds.takeAt(row);
+}
+
 QJsonTreeItem *QJsonTreeItem::child(int row)
 {
     return mChilds.value(row);

--- a/qjsonitem.cpp
+++ b/qjsonitem.cpp
@@ -53,6 +53,17 @@ QList<QJsonTreeItem *> QJsonTreeItem::takeChildren()
 void QJsonTreeItem::setChildren(const QList<QJsonTreeItem *> &children)
 {
     mChilds = children;
+    // Reparent every child. Several callers (insertChildFromJson,
+    // type-conversion paths in QJsonModel::setData) hand us a list
+    // that mixes existing children (whose mParent is already `this`)
+    // with freshly-built ones (mParent = nullptr from
+    // QJsonTreeItem::load()). Without this loop the new nodes leave
+    // mParent dangling, and QJsonModel::parent() crashes on the next
+    // paint (parentItem->row() dereferences null).
+    for (QJsonTreeItem *c : mChilds)
+    {
+        if (c) c->setParent(this);
+    }
 }
 
 

--- a/qjsonitem.h
+++ b/qjsonitem.h
@@ -45,9 +45,17 @@ public:
     DiffColorType colorType() const { return mColorType; }
     QModelIndex idxRelation();
     void clearChildren();
-    
+
     QList<QJsonTreeItem*> takeChildren();
     void setChildren(const QList<QJsonTreeItem*>& children);
+
+    // Single-child structural helpers. Used by QJsonModel's
+    // begin/endInsertRows and begin/endRemoveRows paths so mChilds
+    // is only ever off-by-one during the transaction (never emptied
+    // then refilled), which keeps rowCount() consistent for any
+    // proxy or observer that queries the model mid-transition.
+    void insertChild(int row, QJsonTreeItem *item);
+    QJsonTreeItem *takeChildAt(int row);
     
     static QJsonValue::Type stringToType(const QString& typeName);
     static QJsonTreeItem* load(const QJsonValue& value, QJsonTreeItem * parent = nullptr);

--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -712,6 +712,19 @@ QModelIndex QJsonModel::appendChildFromJson(const QModelIndex &parent,
             && parentItem->type() != QJsonValue::Array)
         return QModelIndex();
 
+    // Object children need a non-empty key. QJsonObject::insert("", v)
+    // is legal but every subsequent empty-key insert overwrites the
+    // prior one on serialize, silently dropping siblings. Refuse here
+    // so integrators don't corrupt JSON by accident; arrays override
+    // the key with the row index a few lines below, so they're unaffected.
+    if (parentItem->type() == QJsonValue::Object && key.isEmpty())
+    {
+        qWarning() << "QJsonModel::appendChildFromJson: empty key for "
+                      "Object parent — rejecting to avoid silent "
+                      "QJsonObject::insert overwrite on serialize.";
+        return QModelIndex();
+    }
+
     // load() returns a wrapper whose own slot represents `source`:
     //  - scalar: type+value set on the wrapper directly; no children.
     //  - container: children built recursively; type left unset on the
@@ -758,11 +771,12 @@ bool QJsonModel::removeRowAt(const QModelIndex &target)
     const QModelIndex parent0 = target.parent();
 
     beginRemoveRows(parent0, row, row);
-    // QJsonTreeItem owns its children — remove from the parent's list
-    // and delete the subtree.
-    QList<QJsonTreeItem*> kids = parentItem->takeChildren();
-    QJsonTreeItem *removed = kids.takeAt(row);
-    parentItem->setChildren(kids);
+    // Single-index takeChildAt keeps mChilds atomically off-by-one
+    // during the transaction (as opposed to the older takeChildren/
+    // setChildren round-trip, which briefly emptied the list — a
+    // window that would let a proxy or nested-event-loop observer
+    // see rowCount()==0 mid-remove and violate the QAIM contract).
+    QJsonTreeItem *removed = parentItem->takeChildAt(row);
     delete removed;
     endRemoveRows();
 
@@ -855,11 +869,9 @@ QModelIndex QJsonModel::insertChildFromJson(const QModelIndex &parent,
                                                  : QModelIndex();
 
     beginInsertRows(parent0, row, row);
-    // QJsonTreeItem owns its children; takeChildren / setChildren is
-    // the safe way to splice in the middle (mirrors removeRowAt).
-    QList<QJsonTreeItem*> kids = parentItem->takeChildren();
-    kids.insert(row, newChild);
-    parentItem->setChildren(kids);
+    // Single-index insertChild keeps mChilds atomically off-by-one
+    // during the transaction. See removeRowAt for the same rationale.
+    parentItem->insertChild(row, newChild);
     endInsertRows();
 
     // Renumber siblings past the insert point so the key column matches

--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -31,7 +31,12 @@
 #include <QJsonArray>
 #include <QIcon>
 #include <QFont>
+#include <QMimeData>
+#include <QSet>
 #include <algorithm>
+
+const QString QJsonModel::kItemMimeType =
+        QStringLiteral("application/x-qjsondiff-item");
 
 QJsonModel::QJsonModel(QObject *parent) :
     QAbstractItemModel(parent)
@@ -388,6 +393,11 @@ bool QJsonModel::setData(const QModelIndex &index, const QVariant &value, int ro
 
         emit dataChanged(index.siblingAtColumn(0), index.siblingAtColumn(columnCount() - 1), {Qt::DisplayRole, Qt::EditRole});
         emit modelChanged();
+        // Structural change — children may have been removed/inserted
+        // by the Object<->Array conversion logic above. Tell listeners
+        // (QJsonContainer) to reset their cached find/goto QModelIndex
+        // lists. Same reason as in replaceFromJson().
+        emit dataUpdated();
         return true;
     }
 
@@ -411,19 +421,29 @@ bool QJsonModel::setData(const QModelIndex &index, const QVariant &value, int ro
 Qt::ItemFlags QJsonModel::flags(const QModelIndex &index) const
 {
     if (!index.isValid())
+    {
+        // Invalid index = the root. Qt consults flags(QModelIndex())
+        // when deciding whether a drop on empty viewport space is OK.
+        // Allow root-level drops only when the root is a container and
+        // the model is editable; otherwise no flags (default behavior).
+        if (mIsEditable && mRootItem
+                && (mRootItem->type() == QJsonValue::Object
+                    || mRootItem->type() == QJsonValue::Array))
+            return Qt::ItemIsDropEnabled;
         return Qt::NoItemFlags;
+    }
 
     Qt::ItemFlags flags = QAbstractItemModel::flags(index);
     if (!mIsEditable)
         return flags;
 
     QJsonTreeItem *item = static_cast<QJsonTreeItem*>(index.internalPointer());
-    
+
     // Type is editable, but not for the root item
     if (index.column() == 1 && item->parent()) {
         flags |= Qt::ItemIsEditable;
     }
-    
+
     // Keys are not editable for array elements
     if (index.column() == 0 && item->parent() && item->parent()->type() != QJsonValue::Array) {
         flags |= Qt::ItemIsEditable;
@@ -436,6 +456,16 @@ Qt::ItemFlags QJsonModel::flags(const QModelIndex &index) const
         item->type() != QJsonValue::Null) {
         flags |= Qt::ItemIsEditable;
     }
+
+    // Drag enabled for any non-root item (root cannot leave the tree).
+    if (item->parent())
+        flags |= Qt::ItemIsDragEnabled;
+
+    // Drop enabled when the item is a container — it can receive
+    // children. The root container is handled via the invalid parent
+    // branch in canDropMimeData().
+    if (item->type() == QJsonValue::Object || item->type() == QJsonValue::Array)
+        flags |= Qt::ItemIsDropEnabled;
 
     return flags;
 }
@@ -607,6 +637,162 @@ QJsonValue::Type QJsonModel::rootType() const
     return mRootItem->type();
 }
 
+bool QJsonModel::replaceFromJson(const QModelIndex &target, const QJsonValue &source)
+{
+    if (!target.isValid() || source.isUndefined())
+        return false;
+    QJsonTreeItem *item = itemFromIndex(target);
+    if (!item)
+        return false;
+
+    // begin/endRemove and begin/endInsert use the column-0 sibling as
+    // the parent index, per Qt model contract.
+    const QModelIndex parent0 = target.siblingAtColumn(0);
+
+    // 1) drop any existing children with proper structural signals so
+    //    selection/expansion state in views stays correct
+    if (item->childCount() > 0)
+    {
+        beginRemoveRows(parent0, 0, item->childCount() - 1);
+        item->clearChildren();
+        endRemoveRows();
+    }
+
+    // 2) overwrite type + value to match the source
+    item->setType(source.type());
+    if (source.isString())
+        item->setValue(source.toString());
+    else if (source.isDouble())
+        item->setValue(QString::number(source.toDouble()));
+    else if (source.isBool())
+        item->setValue(source.toBool() ? QStringLiteral("true") : QStringLiteral("false"));
+    else
+        item->setValue(QString());  // Object/Array/Null carry empty value strings
+
+    // 3) for containers, build a fresh subtree from source and steal
+    //    its children. We use QJsonTreeItem::load() so child key
+    //    numbering / type assignment matches the loadJson() path.
+    if (source.isObject() || source.isArray())
+    {
+        QJsonTreeItem *built = QJsonTreeItem::load(source);
+        QList<QJsonTreeItem*> kids = built->takeChildren();
+        if (!kids.isEmpty())
+        {
+            beginInsertRows(parent0, 0, kids.size() - 1);
+            for (QJsonTreeItem *kid : kids)
+                item->appendChild(kid);
+            endInsertRows();
+        }
+        delete built;  // wrapper drained of children, safe to drop
+    }
+
+    emit dataChanged(parent0,
+                     target.siblingAtColumn(columnCount() - 1),
+                     {Qt::DisplayRole, Qt::EditRole, Qt::DecorationRole});
+    emit modelChanged();
+    // Structural change — children were removed/inserted. Tell listeners
+    // (QJsonContainer) to reset cached find/goto QModelIndex lists and
+    // refresh the diff counter, the same way they react to loadJson.
+    emit dataUpdated();
+    return true;
+}
+
+QModelIndex QJsonModel::appendChildFromJson(const QModelIndex &parent,
+                                            const QString &key,
+                                            const QJsonValue &source)
+{
+    if (source.isUndefined())
+        return QModelIndex();
+
+    QJsonTreeItem *parentItem = parent.isValid() ? itemFromIndex(parent)
+                                                 : mRootItem;
+    if (!parentItem)
+        return QModelIndex();
+    if (parentItem->type() != QJsonValue::Object
+            && parentItem->type() != QJsonValue::Array)
+        return QModelIndex();
+
+    // load() returns a wrapper whose own slot represents `source`:
+    //  - scalar: type+value set on the wrapper directly; no children.
+    //  - container: children built recursively; type left unset on the
+    //    wrapper (loadJson() patches that — we do the same here).
+    QJsonTreeItem *newChild = QJsonTreeItem::load(source);
+    newChild->setType(source.type());
+    newChild->setKey(parentItem->type() == QJsonValue::Array
+                         ? QString::number(parentItem->childCount())
+                         : key);
+
+    const int row = parentItem->childCount();
+    const QModelIndex parent0 = parent.isValid() ? parent.siblingAtColumn(0)
+                                                 : QModelIndex();
+
+    beginInsertRows(parent0, row, row);
+    parentItem->appendChild(newChild);
+    endInsertRows();
+
+    // Parent's childCount text (column 2) may change; refresh its row.
+    if (parent.isValid())
+    {
+        emit dataChanged(parent.siblingAtColumn(0),
+                         parent.siblingAtColumn(columnCount() - 1),
+                         {Qt::DisplayRole, Qt::EditRole, Qt::DecorationRole});
+    }
+    emit modelChanged();
+    emit dataUpdated();
+
+    return index(row, 0, parent0);
+}
+
+bool QJsonModel::removeRowAt(const QModelIndex &target)
+{
+    if (!target.isValid())
+        return false;
+    QJsonTreeItem *item = itemFromIndex(target);
+    if (!item || item == mRootItem)
+        return false;
+    QJsonTreeItem *parentItem = item->parent();
+    if (!parentItem)
+        return false;
+
+    const int row = item->row();
+    const QModelIndex parent0 = target.parent();
+
+    beginRemoveRows(parent0, row, row);
+    // QJsonTreeItem owns its children — remove from the parent's list
+    // and delete the subtree.
+    QList<QJsonTreeItem*> kids = parentItem->takeChildren();
+    QJsonTreeItem *removed = kids.takeAt(row);
+    parentItem->setChildren(kids);
+    delete removed;
+    endRemoveRows();
+
+    // Array children carry stringified-index keys ("0","1","2"…). After
+    // removing one, the survivors past the removal point keep their
+    // original strings, so the display would show "0","2","3" with a
+    // gap. getJsonDocument() serialises by position so the JSON is fine,
+    // but the user sees inconsistent keys. Renumber from `row` onward
+    // and emit dataChanged for the key column.
+    if (parentItem->type() == QJsonValue::Array)
+    {
+        for (int i = row; i < parentItem->childCount(); ++i)
+        {
+            QJsonTreeItem *sibling = parentItem->child(i);
+            const QString want = QString::number(i);
+            if (sibling->key() != want)
+            {
+                sibling->setKey(want);
+                QModelIndex keyIdx = index(i, 0, parent0);
+                emit dataChanged(keyIdx, keyIdx,
+                                 {Qt::DisplayRole, Qt::EditRole});
+            }
+        }
+    }
+
+    emit modelChanged();
+    emit dataUpdated();
+    return true;
+}
+
 QJsonDocument QJsonModel::getJsonDocument() const {
     if (!mRootItem)
         return QJsonDocument();
@@ -621,4 +807,207 @@ QJsonDocument QJsonModel::getJsonDocument() const {
     }
 
     return QJsonDocument();
+}
+
+QModelIndex QJsonModel::insertChildFromJson(const QModelIndex &parent,
+                                            int row,
+                                            const QString &key,
+                                            const QJsonValue &source)
+{
+    if (source.isUndefined())
+        return QModelIndex();
+
+    QJsonTreeItem *parentItem = parent.isValid() ? itemFromIndex(parent)
+                                                 : mRootItem;
+    if (!parentItem)
+        return QModelIndex();
+    if (parentItem->type() != QJsonValue::Object
+            && parentItem->type() != QJsonValue::Array)
+        return QModelIndex();
+
+    const int count = parentItem->childCount();
+    if (row < 0 || row > count) row = count;
+
+    // Append fast-path delegates to appendChildFromJson for the trivial
+    // case and for object parents — object children are unordered by
+    // key, so insert-at-row is the same as append plus a meaningless
+    // visual position change.
+    if (row == count || parentItem->type() == QJsonValue::Object)
+        return appendChildFromJson(parent, key, source);
+
+    // Array mid-insert: build the new child, insert at row, then renumber
+    // siblings past the insert point so the displayed keys stay 0..N-1.
+    QJsonTreeItem *newChild = QJsonTreeItem::load(source);
+    newChild->setType(source.type());
+    newChild->setKey(QString::number(row));
+
+    const QModelIndex parent0 = parent.isValid() ? parent.siblingAtColumn(0)
+                                                 : QModelIndex();
+
+    beginInsertRows(parent0, row, row);
+    // QJsonTreeItem owns its children; takeChildren / setChildren is
+    // the safe way to splice in the middle (mirrors removeRowAt).
+    QList<QJsonTreeItem*> kids = parentItem->takeChildren();
+    kids.insert(row, newChild);
+    parentItem->setChildren(kids);
+    endInsertRows();
+
+    // Renumber siblings past the insert point so the key column matches
+    // their new positions. Mirrors removeRowAt's renumber loop.
+    for (int i = row + 1; i < parentItem->childCount(); ++i)
+    {
+        QJsonTreeItem *sibling = parentItem->child(i);
+        const QString want = QString::number(i);
+        if (sibling->key() != want)
+        {
+            sibling->setKey(want);
+            QModelIndex keyIdx = index(i, 0, parent0);
+            emit dataChanged(keyIdx, keyIdx,
+                             {Qt::DisplayRole, Qt::EditRole});
+        }
+    }
+
+    if (parent.isValid())
+    {
+        emit dataChanged(parent.siblingAtColumn(0),
+                         parent.siblingAtColumn(columnCount() - 1),
+                         {Qt::DisplayRole, Qt::EditRole, Qt::DecorationRole});
+    }
+    emit modelChanged();
+    emit dataUpdated();
+    return index(row, 0, parent0);
+}
+
+// ---------------------------------------------------------------------
+// Drag-and-drop
+// ---------------------------------------------------------------------
+
+Qt::DropActions QJsonModel::supportedDragActions() const
+{
+    // Copy only — the source side keeps its node. The user's mental
+    // model for diff DnD is "duplicate this onto the other side",
+    // not "move it" (which would leave a hole and break ordering on
+    // the source tree).
+    return Qt::CopyAction;
+}
+
+Qt::DropActions QJsonModel::supportedDropActions() const
+{
+    return Qt::CopyAction;
+}
+
+QStringList QJsonModel::mimeTypes() const
+{
+    // Deliberately omit "text/uri-list". File-URL drags must fall
+    // through the tree (which ignores unrecognized MIME) up to the
+    // surrounding QGroupBox where the file-drop event filter lives.
+    return QStringList{kItemMimeType};
+}
+
+QMimeData *QJsonModel::mimeData(const QModelIndexList &indexes) const
+{
+    if (indexes.isEmpty()) return nullptr;
+
+    // Single-item drag only — the tree's selection is single by default
+    // and packing multiple at once raises insertion-order questions we
+    // don't want to answer for v1. Pick the first column-0 sibling.
+    QModelIndex src;
+    for (const QModelIndex &i : indexes)
+    {
+        if (i.isValid() && i.column() == 0) { src = i; break; }
+    }
+    if (!src.isValid()) src = indexes.first();
+    if (!src.isValid()) return nullptr;
+
+    QJsonTreeItem *item = itemFromIndex(src);
+    if (!item || item == mRootItem) return nullptr;
+
+    // Serialise the subtree to a QJsonValue using the same path
+    // getJsonDocument() uses. Scalars come through with their literal
+    // value; containers come through with their nested structure.
+    QJsonValue payload;
+    generateJson(item, payload);
+
+    QJsonObject env;
+    env.insert(QStringLiteral("key"),   item->key());
+    env.insert(QStringLiteral("value"), payload);
+
+    QMimeData *md = new QMimeData;
+    md->setData(kItemMimeType,
+                QJsonDocument(env).toJson(QJsonDocument::Compact));
+    return md;
+}
+
+bool QJsonModel::canDropMimeData(const QMimeData *data, Qt::DropAction action,
+                                 int row, int column,
+                                 const QModelIndex &parent) const
+{
+    Q_UNUSED(row);
+    Q_UNUSED(column);
+    if (!mIsEditable) return false;
+    if (!data || !data->hasFormat(kItemMimeType)) return false;
+    if (action != Qt::CopyAction && action != Qt::IgnoreAction) return false;
+
+    // Drop parent must be a container. Invalid parent = root drop;
+    // accept only if root is a container.
+    if (parent.isValid())
+    {
+        QJsonTreeItem *p = itemFromIndex(parent);
+        if (!p) return false;
+        return p->type() == QJsonValue::Object
+                || p->type() == QJsonValue::Array;
+    }
+    return mRootItem
+            && (mRootItem->type() == QJsonValue::Object
+                || mRootItem->type() == QJsonValue::Array);
+}
+
+bool QJsonModel::dropMimeData(const QMimeData *data, Qt::DropAction action,
+                              int row, int column,
+                              const QModelIndex &parent)
+{
+    Q_UNUSED(column);
+    if (!canDropMimeData(data, action, row, column, parent)) return false;
+    if (action == Qt::IgnoreAction) return true;
+
+    QJsonParseError err;
+    const QJsonDocument doc = QJsonDocument::fromJson(data->data(kItemMimeType), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject())
+        return false;
+    const QJsonObject env = doc.object();
+    const QJsonValue payload = env.value(QStringLiteral("value"));
+    if (payload.isUndefined()) return false;
+    QString key = env.value(QStringLiteral("key")).toString();
+
+    // Resolve the parent item to decide insertion semantics.
+    QJsonTreeItem *parentItem = parent.isValid() ? itemFromIndex(parent)
+                                                 : mRootItem;
+    if (!parentItem) return false;
+
+    // For object parents we need a key that doesn't collide. Take the
+    // source key as a starting suggestion; if empty (e.g. dragged from
+    // an array source where keys are positional) fall back to
+    // "new_key"; then dedupe against existing children.
+    if (parentItem->type() == QJsonValue::Object)
+    {
+        if (key.isEmpty()) key = QStringLiteral("new_key");
+        QSet<QString> used;
+        for (int i = 0; i < parentItem->childCount(); ++i)
+            used.insert(parentItem->child(i)->key());
+        if (used.contains(key))
+        {
+            const QString base = key;
+            for (int k = 1; ; ++k)
+            {
+                key = QStringLiteral("%1_%2").arg(base).arg(k);
+                if (!used.contains(key)) break;
+            }
+        }
+    }
+
+    // row == -1 means "drop on parent" (no specific row). Append.
+    if (row < 0) row = parentItem->childCount();
+
+    QModelIndex newIdx = insertChildFromJson(parent, row, key, payload);
+    return newIdx.isValid();
 }

--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -786,6 +786,16 @@ bool QJsonModel::removeRowAt(const QModelIndex &target)
                                  {Qt::DisplayRole, Qt::EditRole});
             }
         }
+        // Array parent's column 1 shows "Array[N]" — N just changed.
+        // Refresh so views without a full-tree repaint pick up the new
+        // count. Mirrors what appendChildFromJson / insertChildFromJson
+        // already do on the insert side.
+        if (parent0.isValid())
+        {
+            const QModelIndex typeIdx = parent0.siblingAtColumn(1);
+            emit dataChanged(typeIdx, typeIdx,
+                             {Qt::DisplayRole, Qt::EditRole});
+        }
     }
 
     emit modelChanged();

--- a/qjsonmodel.h
+++ b/qjsonmodel.h
@@ -16,6 +16,11 @@
 #include <QStyleOptionViewItem>
 #include <QPainter>
 #include <QStyledItemDelegate>
+#include <QStringList>
+
+QT_BEGIN_NAMESPACE
+class QMimeData;
+QT_END_NAMESPACE
 
 class QJsonModel : public QAbstractItemModel
 {
@@ -48,6 +53,63 @@ public:
     QJsonValue::Type rootType() const;
 
     void setEditable(bool editable);
+
+    // Replace the item at `target` with `source` in place — type, value,
+    // and children are overwritten. The target's *key* is preserved
+    // (the key identifies the item's position in its parent).
+    // Used by the diff-edit "copy from peer" flow. Emits proper
+    // begin/endRemoveRows + begin/endInsertRows + dataChanged so views
+    // keep their selection and scroll state — no model reset.
+    // Returns false if `target` is invalid or `source` is undefined.
+    bool replaceFromJson(const QModelIndex &target, const QJsonValue &source);
+
+    // Append a new child to `parent` built from `source`. For object
+    // parents the new child carries `key`; for array parents the new
+    // child's key is forced to its index-in-parent (matches the
+    // loadJson() convention). `parent` may be invalid to append at the
+    // root level (only valid when the root is Object/Array). Emits
+    // begin/endInsertRows + dataChanged on the parent (its childCount
+    // display changes) + modelChanged + dataUpdated.
+    // Returns the QModelIndex (column 0) of the new child, or invalid.
+    QModelIndex appendChildFromJson(const QModelIndex &parent,
+                                    const QString &key,
+                                    const QJsonValue &source);
+
+    // Remove the row at `target`. Rejects the root. Emits
+    // begin/endRemoveRows + modelChanged + dataUpdated.
+    bool removeRowAt(const QModelIndex &target);
+
+    // Insert a new child at row `row` of `parent`. Sibling of
+    // appendChildFromJson — same key/value semantics, but lets the
+    // caller pick the insertion position. Used by dropMimeData() so
+    // mid-array drops land at the indicated row. `row` is clamped to
+    // [0, childCount]; `row == childCount` is the append case.
+    QModelIndex insertChildFromJson(const QModelIndex &parent,
+                                    int row,
+                                    const QString &key,
+                                    const QJsonValue &source);
+
+    // --- Drag-and-drop ------------------------------------------------
+    // Item-level DnD between two QJsonContainer trees (e.g. the two
+    // sides of a QJsonDiff). Carries a custom MIME type, copy-action
+    // only. Gated by mIsEditable so the read-only contract is
+    // preserved for non-editable usages — flags() omits the drag/drop
+    // bits and dropMimeData/canDropMimeData refuse. File-URL drops
+    // (the existing groupbox file-drop) are NOT in mimeTypes() so the
+    // tree's default dragEnter handler ignores them and they
+    // propagate up to the surrounding groupbox unchanged.
+    Qt::DropActions supportedDragActions() const override;
+    Qt::DropActions supportedDropActions() const override;
+    QStringList     mimeTypes() const override;
+    QMimeData      *mimeData(const QModelIndexList &indexes) const override;
+    bool canDropMimeData(const QMimeData *data, Qt::DropAction action,
+                         int row, int column,
+                         const QModelIndex &parent) const override;
+    bool dropMimeData(const QMimeData *data, Qt::DropAction action,
+                      int row, int column,
+                      const QModelIndex &parent) override;
+
+    static const QString kItemMimeType;
 
 private:
     QJsonTreeItem * mRootItem;

--- a/qjsonmodel.h
+++ b/qjsonmodel.h
@@ -70,6 +70,10 @@ public:
     // root level (only valid when the root is Object/Array). Emits
     // begin/endInsertRows + dataChanged on the parent (its childCount
     // display changes) + modelChanged + dataUpdated.
+    // For Object parents, an empty `key` is rejected (returns invalid)
+    // because QJsonObject::insert("", v) silently overwrites prior
+    // empty-key siblings on serialize. For Array parents, `key` is
+    // ignored — the new child's key is set to its row index.
     // Returns the QModelIndex (column 0) of the new child, or invalid.
     QModelIndex appendChildFromJson(const QModelIndex &parent,
                                     const QString &key,

--- a/qtjsondiff.pro
+++ b/qtjsondiff.pro
@@ -20,17 +20,6 @@ CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
 
 QMAKE_CXXFLAGS += -Wno-implicit-fallthrough
 
-# Opt-in AddressSanitizer + LeakSanitizer: pass CONFIG+=asan at qmake
-# time. Adds runtime instrumentation for use-after-free / leaks. Slower
-# than a clean build, much faster than Valgrind. Never enable for
-# release; never enable when CONFIG+=tests is also set (the test
-# binaries are independent qmake invocations and can't easily share
-# the ASan runtime).
-asan {
-    QMAKE_CXXFLAGS += -fsanitize=address -fno-omit-frame-pointer -g
-    QMAKE_LFLAGS   += -fsanitize=address
-}
-
 SOURCES += main.cpp\
     commandlineparser.cpp \
     jsondiffengine.cpp \
@@ -61,7 +50,6 @@ FORMS    += mainwindow.ui \
     preferences/preferencesdialog.ui
 
 LIBS += -lz
-
 win32:RC_FILE = myapp.rc
 macx:RC_FILE = computer.icns
 
@@ -95,8 +83,7 @@ tests {
         $(QMAKE) $$PWD/tests/tests.pro && \
         $(MAKE) && \
         QT_QPA_PLATFORM=offscreen ./conversions/tst_json_conversions && \
-        QT_QPA_PLATFORM=offscreen ./compare/tst_compare && \
-        ./engine/tst_engine
+        QT_QPA_PLATFORM=offscreen ./compare/tst_compare
 
     QMAKE_EXTRA_TARGETS += check
 }

--- a/tests/compare/test_compare.cpp
+++ b/tests/compare/test_compare.cpp
@@ -534,7 +534,7 @@ private slots:
         QJsonModel *L = diff->getLeftJsonModel();
         QJsonModel *R = diff->getRightJsonModel();
 
-        // Behavioural: the arrow action stays in the toolbar always
+        // Behavioral: the arrow action stays in the toolbar always
         // (so the user's eye doesn't track a vanishing/appearing
         // button), but it's DISABLED on "deep/leaf" because there's
         // nowhere to copy it (parent also missing). It's ENABLED on
@@ -783,7 +783,7 @@ private slots:
         QModelIndex kIdx = resolvePath(L, {"k"});
         QVERIFY(L->setData(kIdx.siblingAtColumn(1), "String"));
 
-        // Pair colour at k flipped to Huge.
+        // Pair color at k flipped to Huge.
         QCOMPARE(colorAt(L, {"k"}), DiffColorType::Huge);
         QCOMPARE(colorAt(R, {"k"}), DiffColorType::Huge);
         // Left's children are gone (Object → String drops them).
@@ -852,7 +852,7 @@ private slots:
 
     // ------------------------------------------------------------------
     // Drag-and-drop: item dropped on the other side becomes gray
-    // (NotPresent) and the drop-target parent's pair colour updates.
+    // (NotPresent) and the drop-target parent's pair color updates.
     // ------------------------------------------------------------------
 
     void dndDropIntoMatchedParentMarksGray()
@@ -878,7 +878,7 @@ private slots:
         delete md;
 
         // The dropped node landed with key "a" already taken → deduped
-        // to "a_1". Its colour is NotPresent (no peer on the left).
+        // to "a_1". Its color is NotPresent (no peer on the left).
         QModelIndex newOnRight = resolvePath(R, {"a_1"});
         QVERIFY(newOnRight.isValid());
         QCOMPARE(R->itemFromIndex(newOnRight)->colorType(),
@@ -886,7 +886,7 @@ private slots:
         // No cross-link — left side has nothing matched here.
         QVERIFY(!R->itemFromIndex(newOnRight)->idxRelation().isValid());
 
-        // Sanity: pre-existing matched siblings keep their colour.
+        // Sanity: pre-existing matched siblings keep their color.
         QCOMPARE(colorAt(R, {"a"}), DiffColorType::Identical);
         QCOMPARE(colorAt(R, {"b"}), DiffColorType::Identical);
     }
@@ -894,7 +894,7 @@ private slots:
     void dndDropIntoNestedContainerRefreshesParent()
     {
         // Drop a new entry into a matched nested object. The dropped
-        // node is NotPresent, and the matched parent's pair colour
+        // node is NotPresent, and the matched parent's pair color
         // refreshes — the parent now has more children on one side.
         loadAndCompare(R"({"obj":{"x":1}})",
                        R"({"obj":{"x":1}})", true);
@@ -916,7 +916,7 @@ private slots:
         QVERIFY(R->dropMimeData(md, Qt::CopyAction, -1, -1, objRight));
         delete md;
 
-        // The dropped duplicate is NotPresent. The parent's pair colour
+        // The dropped duplicate is NotPresent. The parent's pair color
         // is no longer Identical now that the child counts diverge.
         QModelIndex newOnRight = resolvePath(R, {"obj", "x_1"});
         QVERIFY(newOnRight.isValid());

--- a/tests/compare/test_compare.cpp
+++ b/tests/compare/test_compare.cpp
@@ -15,6 +15,7 @@
 #include <QWidget>
 #include <QCheckBox>
 #include <QSignalSpy>
+#include <QMimeData>
 
 #include "qjsondiff.h"
 #include "qjsoncontainer.h"
@@ -291,6 +292,663 @@ private slots:
 
         loadAndCompare(R"({"a":1})", R"({"a":1})", true);
         QCOMPARE(colorAt(diff->getLeftJsonModel(),  {"a"}), DiffColorType::Identical);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase A — edit-in-diff: push selected value INTO peer
+    // ------------------------------------------------------------------
+
+    void editPushLeftScalarToRight()
+    {
+        loadAndCompare(R"({"k":"old"})", R"({"k":"new"})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QModelIndex leftK  = resolvePath(L, {"k"});
+        QModelIndex rightK = resolvePath(R, {"k"});
+
+        QCOMPARE(L->itemFromIndex(leftK)->colorType(),  DiffColorType::Huge);
+        QCOMPARE(R->itemFromIndex(rightK)->colorType(), DiffColorType::Huge);
+
+        diff->getLeftTreeView()->setCurrentIndex(leftK);
+        diff->pushLeftSelectionToRight();
+
+        // Right "k" picked up left's value; both sides resolved.
+        QCOMPARE(R->itemFromIndex(rightK)->value(),     QString("old"));
+        QCOMPARE(L->itemFromIndex(leftK)->colorType(),  DiffColorType::Identical);
+        QCOMPARE(R->itemFromIndex(rightK)->colorType(), DiffColorType::Identical);
+    }
+
+    void editPushRightScalarToLeft()
+    {
+        loadAndCompare(R"({"k":"old"})", R"({"k":"new"})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QModelIndex rightK = resolvePath(R, {"k"});
+
+        diff->getRightTreeView()->setCurrentIndex(rightK);
+        diff->pushRightSelectionToLeft();
+
+        QCOMPARE(L->itemFromIndex(resolvePath(L, {"k"}))->value(),
+                 QString("new"));
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"k"}), DiffColorType::Identical);
+    }
+
+    void editPushDemotesAncestorModerate()
+    {
+        // {"a":{"b":"old"}} vs {"a":{"b":"new"}}
+        // b is Huge, a is Moderate. After push, both Identical.
+        loadAndCompare(R"({"a":{"b":"old"}})",
+                       R"({"a":{"b":"new"}})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QCOMPARE(colorAt(L, {"a"}),       DiffColorType::Moderate);
+        QCOMPARE(colorAt(L, {"a", "b"}),  DiffColorType::Huge);
+
+        QModelIndex leftB = resolvePath(L, {"a", "b"});
+        diff->getLeftTreeView()->setCurrentIndex(leftB);
+        diff->pushLeftSelectionToRight();
+
+        QCOMPARE(colorAt(L, {"a", "b"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(L, {"a"}),      DiffColorType::Identical);  // demoted
+        QCOMPARE(colorAt(R, {"a", "b"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"a"}),      DiffColorType::Identical);
+    }
+
+    void editPushKeepsAncestorModerateWhenSiblingDiffers()
+    {
+        // {"a":{"b":"old","c":"x"}} vs {"a":{"b":"new","c":"y"}}
+        // Push b only — a stays Moderate because c is still Huge.
+        loadAndCompare(R"({"a":{"b":"old","c":"x"}})",
+                       R"({"a":{"b":"new","c":"y"}})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QModelIndex leftB = resolvePath(L, {"a", "b"});
+        diff->getLeftTreeView()->setCurrentIndex(leftB);
+        diff->pushLeftSelectionToRight();
+
+        QCOMPARE(colorAt(L, {"a", "b"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(L, {"a", "c"}), DiffColorType::Huge);
+        QCOMPARE(colorAt(L, {"a"}),      DiffColorType::Moderate);  // not demoted
+    }
+
+    void editPushNoOpWhenEditableOff()
+    {
+        loadAndCompare(R"({"k":"old"})", R"({"k":"new"})", true);
+        // Explicitly reset edit mode (the diff widget is shared across
+        // tests via initTestCase, so a previous test may have toggled
+        // it on). The point of this test: the slot ISN'T gated by
+        // editable — only the overlay button visibility is. The check
+        // below confirms the slot still works programmatically.
+        diff->setDiffEditable(false);
+        QCOMPARE(diff->isDiffEditable(), false);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QModelIndex leftK = resolvePath(L, {"k"});
+        diff->getLeftTreeView()->setCurrentIndex(leftK);
+        diff->pushLeftSelectionToRight();
+
+        // The slot itself is not gated — that's by design (programmatic
+        // use). The overlay is what enforces the user-facing edit-mode
+        // gate. Both sides Identical after this call.
+        QCOMPARE(colorAt(L, {"k"}),                     DiffColorType::Identical);
+        QCOMPARE(colorAt(diff->getRightJsonModel(), {"k"}),
+                                                        DiffColorType::Identical);
+    }
+
+    void editPushArrayShrinksRight()
+    {
+        // Container Huge: same path + same Array type, different child
+        // counts. The compare finds them as a Huge pair with a valid
+        // peer link, so push overwrites the right side's children.
+        loadAndCompare(R"({"k":[1,2]})", R"({"k":[1,2,3,4]})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Huge);
+        QCOMPARE(R->itemFromIndex(resolvePath(R, {"k"}))->childCount(), 4);
+
+        QModelIndex leftK = resolvePath(L, {"k"});
+        diff->getLeftTreeView()->setCurrentIndex(leftK);
+        diff->pushLeftSelectionToRight();
+
+        // Right's array now has 2 elements matching left's.
+        QModelIndex rightK = R->index(0, 0);
+        QCOMPARE(R->itemFromIndex(rightK)->type(),       QJsonValue::Array);
+        QCOMPARE(R->itemFromIndex(rightK)->childCount(), 2);
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"k"}), DiffColorType::Identical);
+    }
+
+    void editPushScalarOverContainerParentChild()
+    {
+        // Parent+Child mode pairs same-key/different-type as Huge
+        // (second-stage fallback), so the push works across types.
+        loadAndCompare(R"({"k":"hello"})",
+                       R"({"k":{"x":1,"y":2}})", false);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Huge);
+        QCOMPARE(colorAt(R, {"k"}), DiffColorType::Huge);
+
+        QModelIndex leftK = resolvePath(L, {"k"});
+        diff->getLeftTreeView()->setCurrentIndex(leftK);
+        diff->pushLeftSelectionToRight();
+
+        QModelIndex rightK = R->index(0, 0);
+        QCOMPARE(R->itemFromIndex(rightK)->type(),       QJsonValue::String);
+        QCOMPARE(R->itemFromIndex(rightK)->value(),      QString("hello"));
+        QCOMPARE(R->itemFromIndex(rightK)->childCount(), 0);
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"k"}), DiffColorType::Identical);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase B — edit-in-diff: push NotPresent INTO other side (insert)
+    //                          and delete-here from one side
+    // ------------------------------------------------------------------
+
+    void editPushNotPresentRootChildToOtherSide()
+    {
+        // {"only_left":1} vs {"only_right":2}. After push left's
+        // "only_left" lands on the right at the root level.
+        loadAndCompare(R"({"only_left":1})", R"({"only_right":2})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QCOMPARE(colorAt(L, {"only_left"}),  DiffColorType::NotPresent);
+        QCOMPARE(colorAt(R, {"only_right"}), DiffColorType::NotPresent);
+
+        diff->getLeftTreeView()->setCurrentIndex(resolvePath(L, {"only_left"}));
+        diff->pushLeftSelectionToRight();
+
+        QVERIFY(exists(R, {"only_left"}));
+        QVERIFY(exists(R, {"only_right"}));
+        QCOMPARE(colorAt(L, {"only_left"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"only_left"}), DiffColorType::Identical);
+        QCOMPARE(R->itemFromIndex(resolvePath(R, {"only_left"}))->value(),
+                 QString("1"));
+    }
+
+    void editPushNotPresentNestedToMatchedParent()
+    {
+        // {"a":{"keep":1,"extra":2}} vs {"a":{"keep":1}}. "extra" is
+        // NotPresent on left under the matched "a". Push appends it
+        // into right's "a".
+        loadAndCompare(R"({"a":{"keep":1,"extra":2}})",
+                       R"({"a":{"keep":1}})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QCOMPARE(colorAt(L, {"a","extra"}), DiffColorType::NotPresent);
+        QVERIFY(!exists(R, {"a","extra"}));
+
+        diff->getLeftTreeView()->setCurrentIndex(resolvePath(L, {"a","extra"}));
+        diff->pushLeftSelectionToRight();
+
+        QVERIFY(exists(R, {"a","extra"}));
+        QCOMPARE(colorAt(L, {"a","extra"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"a","extra"}), DiffColorType::Identical);
+    }
+
+    void editPushNotPresentSubtreeCrossLinksInteriors()
+    {
+        // Pushing a NotPresent CONTAINER must light up its interior
+        // children with idxRelation too — not just the top.
+        loadAndCompare(R"({"keep":0,"big":{"x":1,"y":2}})",
+                       R"({"keep":0})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        diff->getLeftTreeView()->setCurrentIndex(resolvePath(L, {"big"}));
+        diff->pushLeftSelectionToRight();
+
+        QVERIFY(exists(R, {"big","x"}));
+        QVERIFY(exists(R, {"big","y"}));
+        QCOMPARE(colorAt(R, {"big","x"}), DiffColorType::Identical);
+        QCOMPARE(R->itemFromIndex(resolvePath(R, {"big","x"}))->idxRelation().isValid(), true);
+    }
+
+    void editPushNotPresentNoOpWhenParentAlsoMissing()
+    {
+        // {"deep":{"leaf":1}} vs {}. Both "deep" and "deep/leaf" are
+        // NotPresent on left. Push of "deep/leaf" must fail because
+        // its parent has no peer on the right. The user has to push
+        // "deep" first.
+        loadAndCompare(R"({"deep":{"leaf":1}})", R"({})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+
+        // Behavioural: the arrow action stays in the toolbar always
+        // (so the user's eye doesn't track a vanishing/appearing
+        // button), but it's DISABLED on "deep/leaf" because there's
+        // nowhere to copy it (parent also missing). It's ENABLED on
+        // "deep" itself (root is always a valid matched parent on
+        // the other side).
+        QAction *leftPush = nullptr;
+        for (QAction *a : diff->left_cont->toolbar->actions())
+            if (a->text() == QObject::tr("Push to right")) leftPush = a;
+        QVERIFY(leftPush);
+
+        diff->getLeftTreeView()->setCurrentIndex(resolvePath(L, {"deep","leaf"}));
+        QCOMPARE(leftPush->isVisible(), true);
+        QCOMPARE(leftPush->isEnabled(), false);
+
+        diff->getLeftTreeView()->setCurrentIndex(resolvePath(L, {"deep"}));
+        QCOMPARE(leftPush->isVisible(), true);
+        QCOMPARE(leftPush->isEnabled(), true);
+
+        // Clicking "deep/leaf" must still be a safe no-op (defence in
+        // depth — the slot itself should refuse even if the action got
+        // triggered programmatically).
+        diff->getLeftTreeView()->setCurrentIndex(resolvePath(L, {"deep","leaf"}));
+        diff->pushLeftSelectionToRight();
+        QVERIFY(!exists(R, {"deep"}));
+        QVERIFY(!exists(R, {"deep","leaf"}));
+
+        // Then push the parent — both should land in one step.
+        diff->getLeftTreeView()->setCurrentIndex(resolvePath(L, {"deep"}));
+        diff->pushLeftSelectionToRight();
+        QVERIFY(exists(R, {"deep","leaf"}));
+    }
+
+    void editPushNotPresentRightToLeft()
+    {
+        // Symmetric to editPushNotPresentRootChildToOtherSide.
+        loadAndCompare(R"({"a":1})", R"({"a":1,"b":2})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QCOMPARE(colorAt(R, {"b"}), DiffColorType::NotPresent);
+
+        diff->getRightTreeView()->setCurrentIndex(resolvePath(R, {"b"}));
+        diff->pushRightSelectionToLeft();
+
+        QVERIFY(exists(L, {"b"}));
+        QCOMPARE(colorAt(L, {"b"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"b"}), DiffColorType::Identical);
+    }
+
+    void editDeleteNotPresentRemovesRowOnlyFromThatSide()
+    {
+        // Deleting a NotPresent row on left removes it and the right
+        // side is untouched (no peer to orphan).
+        loadAndCompare(R"({"a":1,"only_left":2})", R"({"a":1})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        diff->getLeftTreeView()->setCurrentIndex(resolvePath(L, {"only_left"}));
+        diff->deleteLeftSelection();
+
+        QVERIFY(!exists(L, {"only_left"}));
+        QVERIFY( exists(L, {"a"}));
+        QVERIFY( exists(R, {"a"}));
+    }
+
+    void editDeletePairedRowOrphansPeer()
+    {
+        // Deleting a Huge-paired row on left turns the right peer into
+        // NotPresent (not "removed" on right too — the symmetric
+        // delete is the user's separate next click).
+        loadAndCompare(R"({"k":"old","x":"same"})",
+                       R"({"k":"new","x":"same"})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Huge);
+        QCOMPARE(colorAt(R, {"k"}), DiffColorType::Huge);
+
+        diff->getLeftTreeView()->setCurrentIndex(resolvePath(L, {"k"}));
+        diff->deleteLeftSelection();
+
+        QVERIFY(!exists(L, {"k"}));
+        QVERIFY( exists(R, {"k"}));
+        QCOMPARE(colorAt(R, {"k"}), DiffColorType::NotPresent);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase B+ — single-tree Add child / Delete row on QJsonContainer
+    // ------------------------------------------------------------------
+
+    void containerAddChildToRootObject()
+    {
+        QJsonContainer c(host);
+        c.loadJson(QString(R"({"a":1})"));
+        c.setEditable(true);
+
+        QModelIndex newIdx = c.addChildOf(QModelIndex());
+        QVERIFY(newIdx.isValid());
+        QCOMPARE(c.getJsonModel()->itemFromIndex(newIdx)->key(),
+                 QString("new_key"));
+        QCOMPARE(c.getJsonModel()->itemFromIndex(newIdx)->type(),
+                 QJsonValue::String);
+        QJsonObject out = c.getJsonModel()->getJsonDocument().object();
+        QVERIFY(out.contains("a"));
+        QVERIFY(out.contains("new_key"));
+    }
+
+    void containerAddChildUniqueKeyOnObject()
+    {
+        QJsonContainer c(host);
+        c.loadJson(QString(R"({"new_key":"taken","new_key_1":"also"})"));
+        c.setEditable(true);
+
+        QModelIndex newIdx = c.addChildOf(QModelIndex());
+        QVERIFY(newIdx.isValid());
+        // "new_key" and "new_key_1" already exist → "new_key_2".
+        QCOMPARE(c.getJsonModel()->itemFromIndex(newIdx)->key(),
+                 QString("new_key_2"));
+    }
+
+    void containerAddChildToArrayUsesIndexKey()
+    {
+        QJsonContainer c(host);
+        c.loadJson(QString(R"({"arr":[10,20]})"));
+        c.setEditable(true);
+
+        // Find the "arr" row, append to it.
+        QJsonModel *m = c.getJsonModel();
+        QModelIndex arrIdx;
+        for (int i = 0; i < m->rowCount(QModelIndex()); ++i)
+        {
+            QModelIndex idx = m->index(i, 0, QModelIndex());
+            if (m->itemFromIndex(idx)->key() == "arr") { arrIdx = idx; break; }
+        }
+        QVERIFY(arrIdx.isValid());
+
+        QModelIndex newIdx = c.addChildOf(arrIdx);
+        QVERIFY(newIdx.isValid());
+        // Array auto-keys: third element gets key "2".
+        QCOMPARE(m->itemFromIndex(newIdx)->key(), QString("2"));
+    }
+
+    void containerAddChildRejectsScalarParent()
+    {
+        QJsonContainer c(host);
+        c.loadJson(QString(R"({"k":"x"})"));
+        c.setEditable(true);
+
+        QJsonModel *m = c.getJsonModel();
+        QModelIndex k = m->index(0, 0, QModelIndex());
+        QCOMPARE(m->itemFromIndex(k)->type(), QJsonValue::String);
+
+        QModelIndex newIdx = c.addChildOf(k);
+        QVERIFY(!newIdx.isValid());
+    }
+
+    void containerAddChildNoOpWhenNotEditable()
+    {
+        QJsonContainer c(host);
+        c.loadJson(QString(R"({"a":1})"));
+        // Default: editable off. Add should refuse without flipping
+        // model state (so integrators can wire shortcuts unconditionally).
+        QModelIndex newIdx = c.addChildOf(QModelIndex());
+        QVERIFY(!newIdx.isValid());
+        QCOMPARE(c.getJsonModel()->rowCount(QModelIndex()), 1);
+    }
+
+    void containerRemoveAtRemovesRow()
+    {
+        QJsonContainer c(host);
+        c.loadJson(QString(R"({"a":1,"b":2})"));
+        c.setEditable(true);
+
+        QJsonModel *m = c.getJsonModel();
+        QModelIndex bIdx;
+        for (int i = 0; i < m->rowCount(QModelIndex()); ++i)
+        {
+            QModelIndex idx = m->index(i, 0, QModelIndex());
+            if (m->itemFromIndex(idx)->key() == "b") { bIdx = idx; break; }
+        }
+        QVERIFY(bIdx.isValid());
+        QVERIFY(c.removeAt(bIdx));
+        QJsonObject out = m->getJsonDocument().object();
+        QVERIFY( out.contains("a"));
+        QVERIFY(!out.contains("b"));
+    }
+
+    void editInlineValueChangeFlipsIdenticalToHuge()
+    {
+        // User-reported: an Identical row edited in place stays
+        // Identical. With the dataChanged hook it should flip to Huge
+        // on both sides.
+        loadAndCompare(R"({"k":"v"})", R"({"k":"v"})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Identical);
+
+        QModelIndex valueCell = resolvePath(L, {"k"}).siblingAtColumn(2);
+        QVERIFY(L->setData(valueCell, QString("changed"), Qt::EditRole));
+
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Huge);
+        QCOMPARE(colorAt(R, {"k"}), DiffColorType::Huge);
+    }
+
+    void editInlineKeyRenameDetachesPair()
+    {
+        // Renaming a paired key detaches: both sides go NotPresent
+        // (the slot now names a different item — re-pairing requires
+        // a fresh Compare).
+        loadAndCompare(R"({"k":"v"})", R"({"k":"v"})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Identical);
+
+        QModelIndex keyCell = resolvePath(L, {"k"}).siblingAtColumn(0);
+        QVERIFY(L->setData(keyCell, QString("k_renamed"), Qt::EditRole));
+
+        QCOMPARE(colorAt(L, {"k_renamed"}), DiffColorType::NotPresent);
+        QCOMPARE(colorAt(R, {"k"}),         DiffColorType::NotPresent);
+    }
+
+    void editInlineTypeChangeOnContainerResnapshots()
+    {
+        // {"k":{"x":1}} == {"k":{"x":1}}: identical with paired x.
+        // Change LEFT k's type from Object to String via setData.
+        // Expect: left k = Huge, left k's old child "x" disappears
+        // from the model AND from the snapshot — and right's "x"
+        // gets orphaned to NotPresent (the cross-link points into a
+        // subtree that no longer exists).
+        loadAndCompare(R"({"k":{"x":1}})", R"({"k":{"x":1}})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QCOMPARE(colorAt(L, {"k"}),       DiffColorType::Identical);
+        QCOMPARE(colorAt(L, {"k", "x"}),  DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"k", "x"}),  DiffColorType::Identical);
+
+        QModelIndex kIdx = resolvePath(L, {"k"});
+        QVERIFY(L->setData(kIdx.siblingAtColumn(1), "String"));
+
+        // Pair colour at k flipped to Huge.
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Huge);
+        QCOMPARE(colorAt(R, {"k"}), DiffColorType::Huge);
+        // Left's children are gone (Object → String drops them).
+        QCOMPARE(L->itemFromIndex(kIdx)->childCount(), 0);
+        // Right's x is orphaned (lost its peer).
+        QCOMPARE(colorAt(R, {"k", "x"}), DiffColorType::NotPresent);
+    }
+
+    void editInlineFlipBackToIdenticalWhenValueReverts()
+    {
+        // Edit Identical → Huge → edit back to original → Identical.
+        loadAndCompare(R"({"k":"v"})", R"({"k":"v"})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QModelIndex valueCell = resolvePath(L, {"k"}).siblingAtColumn(2);
+        QVERIFY(L->setData(valueCell, QString("changed"), Qt::EditRole));
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Huge);
+
+        QVERIFY(L->setData(valueCell, QString("v"), Qt::EditRole));
+        QCOMPARE(colorAt(L, {"k"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(diff->getRightJsonModel(), {"k"}),
+                 DiffColorType::Identical);
+    }
+
+    void editDeleteArrayElementRenumbers()
+    {
+        // {"arr":[10,20,30]} vs {"arr":[10,20,30]}, delete arr[1] on
+        // left → left's array becomes [10,30] with keys "0","1" — not
+        // "0","2". Right's "1" becomes NotPresent (orphaned peer) and
+        // right's "2" relationPath slides from {0,2} → {0,1}.
+        loadAndCompare(R"({"arr":[10,20,30]})",
+                       R"({"arr":[10,20,30]})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QModelIndex arrLeft = resolvePath(L, {"arr"});
+        QModelIndex one = L->index(1, 0, arrLeft);
+        diff->getLeftTreeView()->setCurrentIndex(one);
+        diff->deleteLeftSelection();
+
+        QCOMPARE(L->rowCount(arrLeft), 2);
+        QCOMPARE(L->itemFromIndex(L->index(0, 0, arrLeft))->key(), QString("0"));
+        QCOMPARE(L->itemFromIndex(L->index(1, 0, arrLeft))->key(), QString("1"));
+        QCOMPARE(L->itemFromIndex(L->index(1, 0, arrLeft))->value(),
+                 QString("30"));
+        // Right side: orphan + shifted peer.
+        QModelIndex arrRight = resolvePath(R, {"arr"});
+        QCOMPARE(R->itemFromIndex(R->index(1, 0, arrRight))->colorType(),
+                 DiffColorType::NotPresent);
+        // Right's "2" now points at left's slot 1 (formerly slot 2).
+        QCOMPARE(R->itemFromIndex(R->index(2, 0, arrRight))->idxRelation(),
+                 L->index(1, 0, arrLeft));
+    }
+
+    void containerRemoveAtNoOpWhenNotEditable()
+    {
+        QJsonContainer c(host);
+        c.loadJson(QString(R"({"a":1})"));
+        // Default: editable off.
+        QModelIndex aIdx = c.getJsonModel()->index(0, 0, QModelIndex());
+        QVERIFY(!c.removeAt(aIdx));
+        QCOMPARE(c.getJsonModel()->rowCount(QModelIndex()), 1);
+    }
+
+    // ------------------------------------------------------------------
+    // Drag-and-drop: item dropped on the other side becomes gray
+    // (NotPresent) and the drop-target parent's pair colour updates.
+    // ------------------------------------------------------------------
+
+    void dndDropIntoMatchedParentMarksGray()
+    {
+        // Identical objects on both sides → all Identical. Drop a new
+        // key onto the right side: the new node is NotPresent, and the
+        // root pair flips to Huge (child counts diverge) with the root
+        // ancestor going Moderate via the existing fixColors path.
+        loadAndCompare(R"({"a":1,"b":2})",
+                       R"({"a":1,"b":2})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+
+        // Build the MIME payload from the left side, drop onto the
+        // right root. We go through the model's API directly (no
+        // QDrag spin-up) since the slot under test is rowsInserted.
+        QModelIndex a = resolvePath(L, {"a"});
+        QMimeData *md = L->mimeData(QModelIndexList{a});
+        QVERIFY(md);
+        QVERIFY(R->dropMimeData(md, Qt::CopyAction, -1, -1, QModelIndex()));
+        delete md;
+
+        // The dropped node landed with key "a" already taken → deduped
+        // to "a_1". Its colour is NotPresent (no peer on the left).
+        QModelIndex newOnRight = resolvePath(R, {"a_1"});
+        QVERIFY(newOnRight.isValid());
+        QCOMPARE(R->itemFromIndex(newOnRight)->colorType(),
+                 DiffColorType::NotPresent);
+        // No cross-link — left side has nothing matched here.
+        QVERIFY(!R->itemFromIndex(newOnRight)->idxRelation().isValid());
+
+        // Sanity: pre-existing matched siblings keep their colour.
+        QCOMPARE(colorAt(R, {"a"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"b"}), DiffColorType::Identical);
+    }
+
+    void dndDropIntoNestedContainerRefreshesParent()
+    {
+        // Drop a new entry into a matched nested object. The dropped
+        // node is NotPresent, and the matched parent's pair colour
+        // refreshes — the parent now has more children on one side.
+        loadAndCompare(R"({"obj":{"x":1}})",
+                       R"({"obj":{"x":1}})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QModelIndex objLeft  = resolvePath(L, {"obj"});
+        QModelIndex objRight = resolvePath(R, {"obj"});
+
+        // Before: matched.
+        QCOMPARE(R->itemFromIndex(objRight)->colorType(),
+                 DiffColorType::Identical);
+
+        // Drop "x" from left's obj onto right's obj.
+        QModelIndex xLeft = resolvePath(L, {"obj", "x"});
+        QMimeData *md = L->mimeData(QModelIndexList{xLeft});
+        QVERIFY(md);
+        QVERIFY(R->dropMimeData(md, Qt::CopyAction, -1, -1, objRight));
+        delete md;
+
+        // The dropped duplicate is NotPresent. The parent's pair colour
+        // is no longer Identical now that the child counts diverge.
+        QModelIndex newOnRight = resolvePath(R, {"obj", "x_1"});
+        QVERIFY(newOnRight.isValid());
+        QCOMPARE(R->itemFromIndex(newOnRight)->colorType(),
+                 DiffColorType::NotPresent);
+        QVERIFY(R->itemFromIndex(objRight)->colorType() != DiffColorType::Identical);
+    }
+
+    void dndDropPreservesUnaffectedPeerColors()
+    {
+        // Pre-existing matched siblings on both sides keep their
+        // Identical state; only the newly-inserted node is NotPresent.
+        loadAndCompare(R"({"keep":"same","x":1})",
+                       R"({"keep":"same","x":1})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+        QModelIndex x = resolvePath(L, {"x"});
+
+        QMimeData *md = L->mimeData(QModelIndexList{x});
+        QVERIFY(md);
+        QVERIFY(R->dropMimeData(md, Qt::CopyAction, -1, -1, QModelIndex()));
+        delete md;
+
+        // "keep" matched-peer link survives — we asserted on the
+        // pre-drop pair, drop only adds a new node; existing
+        // relationPaths are untouched by the snapshot splice.
+        QCOMPARE(colorAt(L, {"keep"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"keep"}), DiffColorType::Identical);
+        QCOMPARE(R->itemFromIndex(resolvePath(R, {"keep"}))->idxRelation(),
+                 resolvePath(L, {"keep"}));
     }
 };
 

--- a/tests/conversions/test_json_conversions.cpp
+++ b/tests/conversions/test_json_conversions.cpp
@@ -3,6 +3,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QMimeData>
 #include "qjsonmodel.h"
 
 class TestJsonConversions : public QObject
@@ -541,6 +542,284 @@ private slots:
     }
 
     // ------------------------------------------------------------------
+    // replaceFromJson — Phase A "copy from peer" in-place replace
+    // ------------------------------------------------------------------
+
+    void replaceFromJsonScalarOverScalar()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"k":"old"})");
+        QModelIndex k = childByKey(&m, QModelIndex(), "k");
+
+        QVERIFY(m.replaceFromJson(k, QJsonValue(42.0)));
+
+        QCOMPARE(m.itemFromIndex(k)->key(),  QString("k"));     // key preserved
+        QCOMPARE(m.itemFromIndex(k)->type(), QJsonValue::Double);
+        QJsonValue v = m.getJsonDocument().object().value("k");
+        QVERIFY(v.isDouble());
+        QCOMPARE(v.toDouble(), 42.0);
+    }
+
+    void replaceFromJsonContainerOverScalar()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"k":"old"})");
+        QModelIndex k = childByKey(&m, QModelIndex(), "k");
+
+        QJsonObject obj;
+        obj["x"] = 1;
+        obj["y"] = QJsonValue(true);
+        QVERIFY(m.replaceFromJson(k, obj));
+
+        QCOMPARE(m.itemFromIndex(k)->type(),       QJsonValue::Object);
+        QCOMPARE(m.itemFromIndex(k)->childCount(), 2);
+        QJsonObject out = m.getJsonDocument().object().value("k").toObject();
+        QCOMPARE(out.value("x").toDouble(), 1.0);
+        QCOMPARE(out.value("y").toBool(),   true);
+    }
+
+    void replaceFromJsonScalarOverContainer()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"k":{"nested":1,"more":2}})");
+        QModelIndex k = childByKey(&m, QModelIndex(), "k");
+        QCOMPARE(m.itemFromIndex(k)->childCount(), 2);
+
+        QVERIFY(m.replaceFromJson(k, QJsonValue("hello")));
+
+        QCOMPARE(m.itemFromIndex(k)->type(),       QJsonValue::String);
+        QCOMPARE(m.itemFromIndex(k)->childCount(), 0);
+        QCOMPARE(m.getJsonDocument().object().value("k").toString(), QString("hello"));
+    }
+
+    void replaceFromJsonArrayOverArray()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"arr":[1,2,3]})");
+        QModelIndex arr = childByKey(&m, QModelIndex(), "arr");
+        QCOMPARE(m.itemFromIndex(arr)->childCount(), 3);
+
+        QJsonArray newArr;
+        newArr.append("a"); newArr.append("b");
+        QVERIFY(m.replaceFromJson(arr, newArr));
+
+        QCOMPARE(m.itemFromIndex(arr)->childCount(), 2);
+        QJsonArray out = m.getJsonDocument().object().value("arr").toArray();
+        QCOMPARE(out.size(),         2);
+        QCOMPARE(out[0].toString(),  QString("a"));
+        QCOMPARE(out[1].toString(),  QString("b"));
+    }
+
+    void replaceFromJsonEmitsSignals()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"k":"old"})");
+        QModelIndex k = childByKey(&m, QModelIndex(), "k");
+
+        QSignalSpy dataChangedSpy(&m, &QJsonModel::dataChanged);
+        QSignalSpy modelChangedSpy(&m, &QJsonModel::modelChanged);
+        QSignalSpy dataUpdatedSpy(&m, &QJsonModel::dataUpdated);
+
+        QVERIFY(m.replaceFromJson(k, QJsonValue("new")));
+        QVERIFY(dataChangedSpy.count()  >= 1);
+        QCOMPARE(modelChangedSpy.count(), 1);
+        // Structural change → dataUpdated also fires so QJsonContainer
+        // resets its find/goto caches and refreshes the diff counter.
+        QCOMPARE(dataUpdatedSpy.count(), 1);
+    }
+
+    void typeChangeEmitsDataUpdated()
+    {
+        // Pre-existing latent bug, fixed alongside Phase A: the column-1
+        // type-change branch of setData is structural (children
+        // removed/inserted) and must trigger find/goto cache reset.
+        QJsonModel m;
+        m.loadJson(R"({"k":{"x":1,"y":2}})");
+        QModelIndex k = childByKey(&m, QModelIndex(), "k");
+
+        QSignalSpy dataUpdatedSpy(&m, &QJsonModel::dataUpdated);
+        QVERIFY(m.setData(k.siblingAtColumn(1), "String"));  // Object -> String, drops 2 children
+        QCOMPARE(dataUpdatedSpy.count(), 1);
+    }
+
+    void replaceFromJsonRejectsInvalid()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"k":"v"})");
+        QVERIFY(!m.replaceFromJson(QModelIndex(), QJsonValue("x")));
+        QVERIFY(!m.replaceFromJson(m.index(0, 0), QJsonValue(QJsonValue::Undefined)));
+    }
+
+    // ------------------------------------------------------------------
+    // appendChildFromJson / removeRowAt — Phase B "add / delete row"
+    // ------------------------------------------------------------------
+
+    void appendChildScalarToObject()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"a":1})");
+        // root parent, object: key matters.
+        QModelIndex newIdx = m.appendChildFromJson(QModelIndex(), "b", QJsonValue("hi"));
+        QVERIFY(newIdx.isValid());
+        QCOMPARE(m.itemFromIndex(newIdx)->key(),  QString("b"));
+        QCOMPARE(m.itemFromIndex(newIdx)->type(), QJsonValue::String);
+        QJsonObject obj = m.getJsonDocument().object();
+        QCOMPARE(obj.value("a").toDouble(), 1.0);
+        QCOMPARE(obj.value("b").toString(), QString("hi"));
+    }
+
+    void appendChildContainerToObject()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"a":1})");
+        QJsonObject child;
+        child["x"] = 1;
+        child["y"] = QJsonValue(true);
+        QModelIndex newIdx = m.appendChildFromJson(QModelIndex(), "nested", child);
+        QVERIFY(newIdx.isValid());
+        QCOMPARE(m.itemFromIndex(newIdx)->type(),       QJsonValue::Object);
+        QCOMPARE(m.itemFromIndex(newIdx)->childCount(), 2);
+        QJsonObject out = m.getJsonDocument().object();
+        QCOMPARE(out.value("nested").toObject().value("x").toDouble(), 1.0);
+        QCOMPARE(out.value("nested").toObject().value("y").toBool(),   true);
+    }
+
+    void appendChildToArrayUsesIndexAsKey()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"arr":[10,20]})");
+        QModelIndex arrIdx = childByKey(&m, QModelIndex(), "arr");
+        // For arrays, caller-supplied key is ignored; the model uses the
+        // new index. Verifies the loadJson convention is preserved.
+        QModelIndex newIdx = m.appendChildFromJson(arrIdx, "ignored", QJsonValue(30.0));
+        QVERIFY(newIdx.isValid());
+        QCOMPARE(m.itemFromIndex(newIdx)->key(), QString("2"));
+        QJsonArray out = m.getJsonDocument().object().value("arr").toArray();
+        QCOMPARE(out.size(),         3);
+        QCOMPARE(out[2].toDouble(),  30.0);
+    }
+
+    void appendChildRejectsScalarParent()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"scalar":"x"})");
+        QModelIndex sc = childByKey(&m, QModelIndex(), "scalar");
+        QModelIndex newIdx = m.appendChildFromJson(sc, "anything", QJsonValue(1.0));
+        QVERIFY(!newIdx.isValid());
+    }
+
+    void appendChildEmitsSignals()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"a":1})");
+        QSignalSpy modelChangedSpy(&m, &QJsonModel::modelChanged);
+        QSignalSpy dataUpdatedSpy(&m, &QJsonModel::dataUpdated);
+        QVERIFY(m.appendChildFromJson(QModelIndex(), "b", QJsonValue(2.0)).isValid());
+        QCOMPARE(modelChangedSpy.count(), 1);
+        QCOMPARE(dataUpdatedSpy.count(), 1);
+    }
+
+    void removeRowAtScalar()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"a":1,"b":2,"c":3})");
+        QModelIndex bIdx = childByKey(&m, QModelIndex(), "b");
+        QSignalSpy modelChangedSpy(&m, &QJsonModel::modelChanged);
+        QSignalSpy dataUpdatedSpy(&m, &QJsonModel::dataUpdated);
+
+        QVERIFY(m.removeRowAt(bIdx));
+        QCOMPARE(modelChangedSpy.count(), 1);
+        QCOMPARE(dataUpdatedSpy.count(), 1);
+        QJsonObject out = m.getJsonDocument().object();
+        QVERIFY( out.contains("a"));
+        QVERIFY(!out.contains("b"));
+        QVERIFY( out.contains("c"));
+    }
+
+    void removeRowAtContainerWithChildren()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"a":1,"big":{"x":1,"y":2,"z":[1,2,3]},"c":3})");
+        QModelIndex bigIdx = childByKey(&m, QModelIndex(), "big");
+        QVERIFY(m.removeRowAt(bigIdx));
+        QJsonObject out = m.getJsonDocument().object();
+        QVERIFY(!out.contains("big"));
+        QCOMPARE(out.size(), 2);
+    }
+
+    void removeRowAtRejectsInvalidAndRoot()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"a":1})");
+        QVERIFY(!m.removeRowAt(QModelIndex()));     // invalid → rejected
+        // Root has no parent — removeRowAt rejects when item == mRootItem.
+        // We can't construct a "root" QModelIndex except as invalid, so
+        // this is the same case as above; documenting via comment.
+    }
+
+    void removeRowAtRenumbersArrayKeys()
+    {
+        // Array [10,20,30,40]: keys "0","1","2","3". Removing index 1
+        // must renumber to "0","1","2" — not "0","2","3".
+        QJsonModel m;
+        m.loadJson(R"({"arr":[10,20,30,40]})");
+        QModelIndex arr = childByKey(&m, QModelIndex(), "arr");
+        QModelIndex one = m.index(1, 0, arr);
+        QCOMPARE(m.itemFromIndex(one)->key(), QString("1"));
+
+        QVERIFY(m.removeRowAt(one));
+
+        QCOMPARE(m.rowCount(arr), 3);
+        QCOMPARE(m.itemFromIndex(m.index(0, 0, arr))->key(), QString("0"));
+        QCOMPARE(m.itemFromIndex(m.index(1, 0, arr))->key(), QString("1"));
+        QCOMPARE(m.itemFromIndex(m.index(2, 0, arr))->key(), QString("2"));
+        // Values shifted correctly with the renumber.
+        QJsonArray out = m.getJsonDocument().object().value("arr").toArray();
+        QCOMPARE(out.size(),         3);
+        QCOMPARE(out[0].toDouble(),  10.0);
+        QCOMPARE(out[1].toDouble(),  30.0);
+        QCOMPARE(out[2].toDouble(),  40.0);
+    }
+
+    void removeRowAtNoRenumberForObjectKeys()
+    {
+        // Object children carry meaningful keys — those must NOT change
+        // when a sibling is deleted.
+        QJsonModel m;
+        m.loadJson(R"({"a":1,"b":2,"c":3})");
+        QModelIndex bIdx = childByKey(&m, QModelIndex(), "b");
+        QVERIFY(m.removeRowAt(bIdx));
+        QCOMPARE(m.rowCount(QModelIndex()), 2);
+        QCOMPARE(m.itemFromIndex(m.index(0, 0, QModelIndex()))->key(),
+                 QString("a"));
+        QCOMPARE(m.itemFromIndex(m.index(1, 0, QModelIndex()))->key(),
+                 QString("c"));   // not "b"
+    }
+
+    void removeRowAtArrayEmitsKeyDataChanged()
+    {
+        // Renumbering survivors fires dataChanged on the key column so
+        // any view re-fetches the new displayed key.
+        QJsonModel m;
+        m.loadJson(R"({"arr":[10,20,30]})");
+        QModelIndex arr = childByKey(&m, QModelIndex(), "arr");
+        QSignalSpy dataChangedSpy(&m, &QJsonModel::dataChanged);
+
+        QVERIFY(m.removeRowAt(m.index(0, 0, arr)));   // remove "0"
+        // Two surviving siblings renumber from "1","2" → "0","1".
+        // Expect at least one dataChanged per renamed sibling (in
+        // addition to whatever the structural removal emitted).
+        int keyColumnChanges = 0;
+        for (const auto &args : dataChangedSpy)
+        {
+            QModelIndex tl = args.at(0).value<QModelIndex>();
+            if (tl.column() == 0 && tl.parent() == arr)
+                ++keyColumnChanges;
+        }
+        QVERIFY(keyColumnChanges >= 2);
+    }
+
+    // ------------------------------------------------------------------
     // Round-trip after multi-step edits
     // ------------------------------------------------------------------
 
@@ -563,6 +842,206 @@ private slots:
         QJsonModel model2;
         QVERIFY(model2.loadJson(first.toJson()));
         QCOMPARE(model2.getJsonDocument(), first);
+    }
+
+    // ------------------------------------------------------------------
+    // Drag-and-drop: MIME + flags + drop semantics
+    // ------------------------------------------------------------------
+
+    void testDndFlagsRequireEditable()
+    {
+        // Non-editable: drag/drop bits absent. Read-only contract preserved.
+        QJsonModel m;
+        m.loadJson(R"({"a":1,"b":[10,20]})");
+        QModelIndex a = childByKey(&m, QModelIndex(), "a");
+        QVERIFY(!(m.flags(a) & Qt::ItemIsDragEnabled));
+        QVERIFY(!(m.flags(QModelIndex()) & Qt::ItemIsDropEnabled));
+
+        // Editable: any non-root item is draggable; containers (Object,
+        // Array, and root because root is an Object here) accept drops.
+        m.setEditable(true);
+        QVERIFY(m.flags(a) & Qt::ItemIsDragEnabled);
+        QModelIndex b = childByKey(&m, QModelIndex(), "b");
+        QVERIFY(m.flags(b) & Qt::ItemIsDragEnabled);
+        QVERIFY(m.flags(b) & Qt::ItemIsDropEnabled);       // array
+        QVERIFY(m.flags(QModelIndex()) & Qt::ItemIsDropEnabled);  // root object
+    }
+
+    void testDndScalarRejectsDrops()
+    {
+        // A scalar value cannot accept children — flag is off, and
+        // canDropMimeData refuses.
+        QJsonModel m;
+        m.setEditable(true);
+        m.loadJson(R"({"s":"hi","arr":[1]})");
+        QModelIndex s = childByKey(&m, QModelIndex(), "s");
+        QVERIFY(!(m.flags(s) & Qt::ItemIsDropEnabled));
+
+        // Build a valid payload and verify canDropMimeData says no.
+        QModelIndex src = m.index(0, 0, childByKey(&m, QModelIndex(), "arr"));
+        QMimeData *md = m.mimeData(QModelIndexList{src});
+        QVERIFY(md);
+        QVERIFY(!m.canDropMimeData(md, Qt::CopyAction, -1, -1, s));
+        delete md;
+    }
+
+    void testDndMimeRoundTripScalar()
+    {
+        // mimeData of an array element + dropMimeData onto an object
+        // parent yields a new child with the source value.
+        QJsonModel m;
+        m.setEditable(true);
+        m.loadJson(R"({"obj":{},"arr":[42,"hi",true]})");
+        QModelIndex arr = childByKey(&m, QModelIndex(), "arr");
+        QModelIndex obj = childByKey(&m, QModelIndex(), "obj");
+
+        QMimeData *md = m.mimeData(QModelIndexList{m.index(0, 0, arr)});
+        QVERIFY(md);
+        QVERIFY(m.canDropMimeData(md, Qt::CopyAction, -1, -1, obj));
+        QVERIFY(m.dropMimeData(md, Qt::CopyAction, -1, -1, obj));
+        delete md;
+
+        // Object parent: source key was "0" (array index) — pre-deduped
+        // because "0" doesn't exist in obj — so the new entry's key is
+        // "0" and value is 42.
+        QCOMPARE(m.rowCount(obj), 1);
+        QModelIndex newChild = m.index(0, 0, obj);
+        QCOMPARE(m.itemFromIndex(newChild)->key(),   QStringLiteral("0"));
+        QCOMPARE(m.itemFromIndex(newChild)->value(), QStringLiteral("42"));
+        QCOMPARE(m.itemFromIndex(newChild)->type(),  QJsonValue::Double);
+    }
+
+    void testDndMimeRoundTripContainer()
+    {
+        // Dropping a nested subtree preserves structure all the way down.
+        QJsonModel m;
+        m.setEditable(true);
+        m.loadJson(R"({"src":{"deep":{"k":"v","list":[1,2]}},"dst":{}})");
+        QModelIndex deep = childByKey(&m,
+                                      childByKey(&m, QModelIndex(), "src"),
+                                      "deep");
+        QModelIndex dst = childByKey(&m, QModelIndex(), "dst");
+
+        QMimeData *md = m.mimeData(QModelIndexList{deep});
+        QVERIFY(md);
+        QVERIFY(m.dropMimeData(md, Qt::CopyAction, -1, -1, dst));
+        delete md;
+
+        // dst now has a "deep" child mirroring the source.
+        QModelIndex newDeep = childByKey(&m, dst, "deep");
+        QVERIFY(newDeep.isValid());
+        QCOMPARE(m.itemFromIndex(newDeep)->type(), QJsonValue::Object);
+        QCOMPARE(m.rowCount(newDeep), 2);
+        QVERIFY(childByKey(&m, newDeep, "k").isValid());
+        QVERIFY(childByKey(&m, newDeep, "list").isValid());
+        QCOMPARE(m.rowCount(childByKey(&m, newDeep, "list")), 2);
+    }
+
+    void testDndObjectKeyDedup()
+    {
+        // Dropping a child with a key that collides with an existing
+        // sibling key gets a "_1" / "_2" suffix.
+        QJsonModel m;
+        m.setEditable(true);
+        m.loadJson(R"({"a":{"x":1},"b":{"x":2}})");
+        QModelIndex a = childByKey(&m, QModelIndex(), "a");
+        QModelIndex b = childByKey(&m, QModelIndex(), "b");
+
+        QMimeData *md = m.mimeData(QModelIndexList{m.index(0, 0, a)});
+        QVERIFY(md);
+        QVERIFY(m.dropMimeData(md, Qt::CopyAction, -1, -1, b));
+        delete md;
+
+        // b now has "x" (existing) and "x_1" (the dropped copy).
+        QCOMPARE(m.rowCount(b), 2);
+        QVERIFY(childByKey(&m, b, "x").isValid());
+        QVERIFY(childByKey(&m, b, "x_1").isValid());
+    }
+
+    void testDndArrayMidRowInsert()
+    {
+        // dropMimeData with a specific row on an array inserts at that
+        // position; surviving siblings renumber to keep their displayed
+        // keys consecutive (matches removeRowAt's invariant).
+        QJsonModel m;
+        m.setEditable(true);
+        m.loadJson(R"({"src":99,"arr":[10,20,30]})");
+        QModelIndex src = childByKey(&m, QModelIndex(), "src");
+        QModelIndex arr = childByKey(&m, QModelIndex(), "arr");
+
+        QMimeData *md = m.mimeData(QModelIndexList{src});
+        QVERIFY(md);
+        QVERIFY(m.dropMimeData(md, Qt::CopyAction, 1, -1, arr));  // insert at row 1
+        delete md;
+
+        QCOMPARE(m.rowCount(arr), 4);
+        // arr is now [10, 99, 20, 30] with keys "0","1","2","3".
+        for (int i = 0; i < 4; ++i)
+        {
+            QModelIndex c = m.index(i, 0, arr);
+            QCOMPARE(m.itemFromIndex(c)->key(), QString::number(i));
+        }
+        QCOMPARE(m.itemFromIndex(m.index(0, 0, arr))->value(), QStringLiteral("10"));
+        QCOMPARE(m.itemFromIndex(m.index(1, 0, arr))->value(), QStringLiteral("99"));
+        QCOMPARE(m.itemFromIndex(m.index(2, 0, arr))->value(), QStringLiteral("20"));
+        QCOMPARE(m.itemFromIndex(m.index(3, 0, arr))->value(), QStringLiteral("30"));
+    }
+
+    void testDndRejectsWhenNotEditable()
+    {
+        // dropMimeData refuses outright when the model is not editable,
+        // even if the MIME payload is well-formed. canDropMimeData also
+        // says no. Source side can still mimeData (read-only inspection),
+        // but the destination side won't accept it.
+        QJsonModel src;
+        src.setEditable(true);
+        src.loadJson(R"({"x":1})");
+        QModelIndex x = childByKey(&src, QModelIndex(), "x");
+        QMimeData *md = src.mimeData(QModelIndexList{x});
+        QVERIFY(md);
+
+        QJsonModel dst;
+        dst.loadJson(R"({"y":2})");  // NOT editable
+        QVERIFY(!dst.canDropMimeData(md, Qt::CopyAction, -1, -1, QModelIndex()));
+        QVERIFY(!dst.dropMimeData(md, Qt::CopyAction, -1, -1, QModelIndex()));
+        QCOMPARE(dst.rowCount(QModelIndex()), 1);  // unchanged
+        delete md;
+    }
+
+    void testDndDropAtRoot()
+    {
+        // Empty / invalid parent = root. Allowed when root is a container
+        // and model is editable.
+        QJsonModel m;
+        m.setEditable(true);
+        m.loadJson(R"({"a":1})");
+
+        QJsonObject env;
+        env.insert("key",   "b");
+        env.insert("value", 42);
+        QMimeData md;
+        md.setData(QJsonModel::kItemMimeType,
+                   QJsonDocument(env).toJson(QJsonDocument::Compact));
+
+        QVERIFY(m.canDropMimeData(&md, Qt::CopyAction, -1, -1, QModelIndex()));
+        QVERIFY(m.dropMimeData(&md, Qt::CopyAction, -1, -1, QModelIndex()));
+        QCOMPARE(m.rowCount(QModelIndex()), 2);
+        QVERIFY(childByKey(&m, QModelIndex(), "b").isValid());
+    }
+
+    void testDndFileUrlMimeIgnored()
+    {
+        // Sanity: a text/uri-list MIME payload (what a file drag carries)
+        // is rejected by the model — keeps the existing file-drop path on
+        // the surrounding groupbox eventFilter free of contention.
+        QJsonModel m;
+        m.setEditable(true);
+        m.loadJson(R"({"a":1})");
+
+        QMimeData md;
+        md.setData("text/uri-list", "file:///tmp/example.json\r\n");
+        QVERIFY(!m.canDropMimeData(&md, Qt::CopyAction, -1, -1, QModelIndex()));
+        QVERIFY(!m.dropMimeData(&md, Qt::CopyAction, -1, -1, QModelIndex()));
     }
 };
 

--- a/tests/conversions/test_json_conversions.cpp
+++ b/tests/conversions/test_json_conversions.cpp
@@ -4,6 +4,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QMimeData>
+#include <QRegularExpression>
 #include "qjsonmodel.h"
 
 class TestJsonConversions : public QObject
@@ -719,6 +720,64 @@ private slots:
         QCOMPARE(dataUpdatedSpy.count(), 1);
     }
 
+    void appendChildRejectsEmptyKeyForObject()
+    {
+        // QJsonObject::insert("", v) is legal but every subsequent
+        // empty-key insert overwrites the prior one on serialize. The
+        // model refuses to accept the empty key so integrators don't
+        // silently corrupt JSON.
+        QJsonModel m;
+        m.loadJson(R"({"a":1})");
+        QSignalSpy modelChangedSpy(&m, &QJsonModel::modelChanged);
+        QSignalSpy dataUpdatedSpy(&m, &QJsonModel::dataUpdated);
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("appendChildFromJson: empty key for Object parent"));
+        QModelIndex newIdx = m.appendChildFromJson(QModelIndex(),
+                                                  QString(),
+                                                  QJsonValue(2.0));
+        QVERIFY(!newIdx.isValid());
+        QCOMPARE(modelChangedSpy.count(), 0);
+        QCOMPARE(dataUpdatedSpy.count(), 0);
+        // Tree intact.
+        QJsonObject out = m.getJsonDocument().object();
+        QCOMPARE(out.size(), 1);
+        QCOMPARE(out.value("a").toDouble(), 1.0);
+    }
+
+    void appendChildEmptyKeyForArrayIsFine()
+    {
+        // Arrays override the caller's key with the row index, so an
+        // empty key is harmless on that path.
+        QJsonModel m;
+        m.loadJson(R"({"arr":[10,20]})");
+        QModelIndex arrIdx = childByKey(&m, QModelIndex(), "arr");
+        QModelIndex newIdx = m.appendChildFromJson(arrIdx,
+                                                   QString(),
+                                                   QJsonValue(30.0));
+        QVERIFY(newIdx.isValid());
+        QCOMPARE(m.itemFromIndex(newIdx)->key(), QString("2"));
+        QJsonArray out = m.getJsonDocument().object().value("arr").toArray();
+        QCOMPARE(out.size(),        3);
+        QCOMPARE(out[2].toDouble(), 30.0);
+    }
+
+    void insertChildRejectsEmptyKeyForObject()
+    {
+        // insertChildFromJson delegates to appendChildFromJson for
+        // Object parents (object children are unordered) so the empty-
+        // key rejection should propagate without a separate guard.
+        QJsonModel m;
+        m.loadJson(R"({"a":1,"b":2})");
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("appendChildFromJson: empty key for Object parent"));
+        QModelIndex newIdx = m.insertChildFromJson(QModelIndex(), 0,
+                                                  QString(),
+                                                  QJsonValue(3.0));
+        QVERIFY(!newIdx.isValid());
+        QJsonObject out = m.getJsonDocument().object();
+        QCOMPARE(out.size(), 2);
+    }
+
     void removeRowAtScalar()
     {
         QJsonModel m;
@@ -745,6 +804,70 @@ private slots:
         QJsonObject out = m.getJsonDocument().object();
         QVERIFY(!out.contains("big"));
         QCOMPARE(out.size(), 2);
+    }
+
+    void removeRowAtKeepsRowCountConsistentAcrossSignals()
+    {
+        // I-001: Between beginRemoveRows and endRemoveRows the model
+        // must report the pre-remove row count (Qt QAIM contract).
+        // The pre-fix implementation did takeChildren() + setChildren()
+        // which briefly emptied the parent's mChilds — so an observer
+        // that queried rowCount() mid-transaction saw 0.
+        //
+        // This test connects a lambda to rowsAboutToBeRemoved that
+        // queries rowCount(parent). If the pre-remove state is intact,
+        // the returned count matches the initial count.
+        QJsonModel m;
+        m.loadJson(R"({"a":1,"b":2,"c":3})");
+        const int initial = m.rowCount(QModelIndex());
+        QCOMPARE(initial, 3);
+
+        int observedInAboutTo = -1;
+        int observedInRemoved = -1;
+        QObject::connect(&m, &QAbstractItemModel::rowsAboutToBeRemoved,
+                         [&](const QModelIndex &p, int, int) {
+                             observedInAboutTo = m.rowCount(p);
+                         });
+        QObject::connect(&m, &QAbstractItemModel::rowsRemoved,
+                         [&](const QModelIndex &p, int, int) {
+                             observedInRemoved = m.rowCount(p);
+                         });
+
+        QModelIndex bIdx = childByKey(&m, QModelIndex(), "b");
+        QVERIFY(m.removeRowAt(bIdx));
+
+        QCOMPARE(observedInAboutTo, initial);       // pre-remove state
+        QCOMPARE(observedInRemoved, initial - 1);   // post-remove state
+    }
+
+    void insertChildFromJsonKeepsRowCountConsistentAcrossSignals()
+    {
+        // Symmetric guard for insertChildFromJson's array-mid-insert
+        // path. Between beginInsertRows and endInsertRows the model
+        // must report the pre-insert row count in rowsAboutToBeInserted
+        // and the post-insert count in rowsInserted.
+        QJsonModel m;
+        m.loadJson(R"({"arr":[10,20,30,40]})");
+        QModelIndex arr = childByKey(&m, QModelIndex(), "arr");
+        const int initial = m.rowCount(arr);
+        QCOMPARE(initial, 4);
+
+        int observedInAboutTo = -1;
+        int observedInInserted = -1;
+        QObject::connect(&m, &QAbstractItemModel::rowsAboutToBeInserted,
+                         [&](const QModelIndex &p, int, int) {
+                             observedInAboutTo = m.rowCount(p);
+                         });
+        QObject::connect(&m, &QAbstractItemModel::rowsInserted,
+                         [&](const QModelIndex &p, int, int) {
+                             observedInInserted = m.rowCount(p);
+                         });
+
+        // row=2 forces the mid-insert path (row != count, array parent).
+        QVERIFY(m.insertChildFromJson(arr, 2, QString(), QJsonValue(25.0)).isValid());
+
+        QCOMPARE(observedInAboutTo, initial);       // pre-insert
+        QCOMPARE(observedInInserted, initial + 1);  // post-insert
     }
 
     void removeRowAtRejectsInvalidAndRoot()

--- a/tests/engine/test_engine.cpp
+++ b/tests/engine/test_engine.cpp
@@ -507,6 +507,61 @@ private slots:
         QCOMPARE(ml.itemFromIndex(backToA)->key(), QString("a"));
     }
 
+    void applyPathWritesOnlyAlongPath()
+    {
+        // Setup: {a:1, b:{c:1, d:2}, e:3} vs {a:1, b:{c:1, d:9}, e:3}.
+        // After compare + full apply, b.d is Huge, b is Moderate, root
+        // is Moderate. Verify applyPath along path=[1,1] (b.d) touches
+        // exactly the ancestors and the leaf while leaving unrelated
+        // siblings' color/idxRelation intact — no layoutChanged fires.
+        QJsonModel ml;
+        ml.loadJson(R"({"a":1,"b":{"c":1,"d":2},"e":3})");
+        QJsonModel mr;
+        mr.loadJson(R"({"a":1,"b":{"c":1,"d":9},"e":3})");
+
+        DiffNode L = JsonDiffEngine::snapshot(&ml);
+        DiffNode R = JsonDiffEngine::snapshot(&mr);
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        JsonDiffEngine::apply(L, &ml, &mr);
+        JsonDiffEngine::apply(R, &mr, &ml);
+
+        // Baseline state after full apply.
+        QModelIndex bL   = ml.index(1, 0);
+        QModelIndex bcL  = ml.index(0, 0, bL);
+        QModelIndex bdL  = ml.index(1, 0, bL);
+        QModelIndex eL   = ml.index(2, 0);
+        QCOMPARE(ml.itemFromIndex(bdL)->colorType(), DiffColorType::Huge);
+        QCOMPARE(ml.itemFromIndex(bL) ->colorType(), DiffColorType::Moderate);
+        QCOMPARE(ml.itemFromIndex(bcL)->colorType(), DiffColorType::Identical);
+        QCOMPARE(ml.itemFromIndex(eL) ->colorType(), DiffColorType::Identical);
+
+        // Corrupt siblings' state — applyPath must NOT overwrite them
+        // (they're outside the path). If applyPath walked the whole
+        // tree it would restore these from the snapshot.
+        ml.itemFromIndex(bcL)->setColorType(DiffColorType::None);
+        ml.itemFromIndex(eL) ->setColorType(DiffColorType::None);
+
+        // No layoutChanged should fire on a targeted applyPath — the
+        // whole point of the fast path is to avoid the persistent-
+        // index remap. Dataupdated is emitted for the counter widget.
+        QSignalSpy layoutSpy(&ml, &QAbstractItemModel::layoutChanged);
+        QSignalSpy dataChangedSpy(&ml, &QAbstractItemModel::dataChanged);
+        QSignalSpy dataUpdatedSpy(&ml, &QJsonModel::dataUpdated);
+
+        JsonDiffEngine::applyPath(L, &ml, {1, 1}, &mr);
+
+        QCOMPARE(layoutSpy.count(), 0);
+        QVERIFY (dataChangedSpy.count() >= 2);   // b + b.d rows
+        QCOMPARE(dataUpdatedSpy.count(), 1);
+        // Path targets refreshed from snapshot.
+        QCOMPARE(ml.itemFromIndex(bdL)->colorType(), DiffColorType::Huge);
+        QCOMPARE(ml.itemFromIndex(bL) ->colorType(), DiffColorType::Moderate);
+        // Off-path siblings were left corrupted — applyPath did NOT
+        // touch them, proving it walked only the path.
+        QCOMPARE(ml.itemFromIndex(bcL)->colorType(), DiffColorType::None);
+        QCOMPARE(ml.itemFromIndex(eL) ->colorType(), DiffColorType::None);
+    }
+
     // ------------------------------------------------------------------
     // Phase A: copyPeer + recomparePair
     // Targeted edit-and-recompare — what the diff-edit overlay button
@@ -1010,6 +1065,63 @@ private slots:
                                            JsonDiffEngine::Mode::FullPath));
         QCOMPARE(L.children[0].color, DiffColorType::NotPresent);
         QCOMPARE(R.children[0].color, DiffColorType::NotPresent);
+    }
+
+    void removePeerSetsParentHugeWhenSizesNowDiffer()
+    {
+        // Original main-branch rule (compareValue): paired Object/Array
+        // containers with mismatched child counts BOTH go Huge. After
+        // an edit-driven delete, removePeer must replay that rule so
+        // the user sees the same "this object now differs" signal they
+        // would get from a fresh Compare.
+        //
+        // ParentChildPair pairs items by parent.key+key+type, which can
+        // place peers at different indices on the two sides — that
+        // structural skew is also what made the old "approximate"
+        // ancestor walk land on the wrong subtree.
+        //
+        // Setup: left {"a":{"x":1,"y":9},"z":2},
+        //        right {"z":2,"a":{"x":1,"y":8}}.
+        // After Compare (ParentChildPair):
+        //   L.a [0]   pairs R.a [1] — same size, Identical → Moderate
+        //                            after fixColors promotes via y.
+        //   L.a.x [0,0] pairs R.a.x [1,0] — Identical.
+        //   L.a.y [0,1] pairs R.a.y [1,1] — Huge (9 vs 8).
+        //   L.z [1]   pairs R.z [0] — Identical.
+        DiffNode L = makeRoot();
+        DiffNode a_l = makeContainer("a", QJsonValue::Object);
+        a_l.children.append(makeScalar("x", QJsonValue::Double, "1"));
+        a_l.children.append(makeScalar("y", QJsonValue::Double, "9"));
+        L.children.append(a_l);
+        L.children.append(makeScalar("z", QJsonValue::Double, "2"));
+
+        DiffNode R = makeRoot();
+        R.children.append(makeScalar("z", QJsonValue::Double, "2"));
+        DiffNode a_r = makeContainer("a", QJsonValue::Object);
+        a_r.children.append(makeScalar("x", QJsonValue::Double, "1"));
+        a_r.children.append(makeScalar("y", QJsonValue::Double, "8"));
+        R.children.append(a_r);
+
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::ParentChildPair);
+
+        // Pre-delete sanity: both `a` sides Moderate via Huge child y.
+        QCOMPARE(L.children[0].color, DiffColorType::Moderate);   // L.a
+        QCOMPARE(R.children[1].color, DiffColorType::Moderate);   // R.a
+        QCOMPARE(R.children[1].children[1].color, DiffColorType::Huge); // R.a.y
+
+        QVERIFY(JsonDiffEngine::removePeer(L, {0, 1}, R,
+                                           JsonDiffEngine::Mode::ParentChildPair));
+
+        // R.a.y is the orphan — no peer on the (now-smaller) src side.
+        QCOMPARE(R.children[1].children[1].color, DiffColorType::NotPresent);
+        QVERIFY (R.children[1].children[1].relationPath.isEmpty());
+        // Sizes differ (L.a has 1 child, R.a still has 2) → both `a`
+        // sides go Huge per the original rule. Roots get promoted to
+        // Moderate (Huge child counts as a diff descendant).
+        QCOMPARE(L.children[0].color, DiffColorType::Huge);       // L.a
+        QCOMPARE(R.children[1].color, DiffColorType::Huge);       // R.a
+        QCOMPARE(L.color,             DiffColorType::Moderate);   // L root
+        QCOMPARE(R.color,             DiffColorType::Moderate);   // R root
     }
 
     void removePeerSubtreeOrphansAllDescendants()

--- a/tests/engine/test_engine.cpp
+++ b/tests/engine/test_engine.cpp
@@ -186,7 +186,7 @@ private slots:
 
     // Full-path: type mismatch -> NotPresent (path includes type).
     // ParentChild: type mismatch -> Huge (second-stage key-only match).
-    // Both behaviours are locked in here so a future refactor can't
+    // Both behaviors are locked in here so a future refactor can't
     // silently change them.
     void sameKeyDifferentType_full()
     {
@@ -321,8 +321,8 @@ private slots:
     {
         // compareAsync should emit phaseChanged at every algorithm
         // boundary. FullPath: Building paths, Matching paths,
-        // Comparing values, Resolving colours. ParentChild: Indexing
-        // right tree, Pairing items, Resolving colours. Verify the
+        // Comparing values, Resolving colors. ParentChild: Indexing
+        // right tree, Pairing items, Resolving colors. Verify the
         // FullPath path here — exact set + ordering.
         QJsonModel left, right;
         left.loadJson(R"({"a":1,"b":2})");
@@ -336,9 +336,9 @@ private slots:
         eng.moveToThread(&t);
         t.start();
 
-        QStringList phases;
+        QList<JsonDiffEngine::Phase> phases;
         QObject::connect(&eng, &JsonDiffEngine::phaseChanged,
-                         [&](const QString &p) { phases.append(p); });
+                         [&](JsonDiffEngine::Phase p) { phases.append(p); });
 
         QSignalSpy finishedSpy(&eng, &JsonDiffEngine::finished);
         QMetaObject::invokeMethod(&eng, "compareAsync", Qt::QueuedConnection,
@@ -347,17 +347,17 @@ private slots:
             Q_ARG(JsonDiffEngine::Mode, JsonDiffEngine::Mode::FullPath));
         QVERIFY(finishedSpy.wait(2000));
 
-        QCOMPARE(phases, QStringList({
-            "Building paths",
-            "Matching paths",
-            "Comparing values",
-            "Resolving colours"
+        QCOMPARE(phases, QList<JsonDiffEngine::Phase>({
+            JsonDiffEngine::Phase::BuildingPaths,
+            JsonDiffEngine::Phase::MatchingPaths,
+            JsonDiffEngine::Phase::ComparingValues,
+            JsonDiffEngine::Phase::ResolvingColors
         }));
     }
 
     void asyncCompareParentChildPhases()
     {
-        // ParentChildPair: Indexing right tree, Pairing items, Resolving colours.
+        // ParentChildPair: Indexing right tree, Pairing items, Resolving colors.
         QJsonModel left, right;
         left.loadJson(R"({"a":1})");
         right.loadJson(R"({"a":1})");
@@ -370,9 +370,9 @@ private slots:
         eng.moveToThread(&t);
         t.start();
 
-        QStringList phases;
+        QList<JsonDiffEngine::Phase> phases;
         QObject::connect(&eng, &JsonDiffEngine::phaseChanged,
-                         [&](const QString &p) { phases.append(p); });
+                         [&](JsonDiffEngine::Phase p) { phases.append(p); });
 
         QSignalSpy finishedSpy(&eng, &JsonDiffEngine::finished);
         QMetaObject::invokeMethod(&eng, "compareAsync", Qt::QueuedConnection,
@@ -381,10 +381,10 @@ private slots:
             Q_ARG(JsonDiffEngine::Mode, JsonDiffEngine::Mode::ParentChildPair));
         QVERIFY(finishedSpy.wait(2000));
 
-        QCOMPARE(phases, QStringList({
-            "Indexing right tree",
-            "Pairing items",
-            "Resolving colours"
+        QCOMPARE(phases, QList<JsonDiffEngine::Phase>({
+            JsonDiffEngine::Phase::IndexingRightTree,
+            JsonDiffEngine::Phase::PairingItems,
+            JsonDiffEngine::Phase::ResolvingColors
         }));
     }
 
@@ -411,7 +411,7 @@ private slots:
         QCOMPARE(finishedSpy.count(), 1);
 
         // Same shared object came back — the trees were mutated in place,
-        // not copied. Verify the colour reached our local pointer too.
+        // not copied. Verify the color reached our local pointer too.
         QCOMPARE(L->children[0].color, DiffColorType::Identical);
 
         // The signal's first argument is the same shared pointer.
@@ -979,7 +979,7 @@ private slots:
         QVERIFY(JsonDiffEngine::resnapshotSubtree(L, {0}, &ml, R));
 
         // Peer of L[0] (R[0]) is left intact — recomparePair handles
-        // its colour after this call. Its DESCENDANT was orphaned.
+        // its color after this call. Its DESCENDANT was orphaned.
         QCOMPARE(R.children[0].children[0].color,        DiffColorType::NotPresent);
         QVERIFY (R.children[0].children[0].relationPath.isEmpty());
         // The pair at the top of the subtree is untouched here.
@@ -1044,7 +1044,7 @@ private slots:
         // Root's color: NotPresent descendants don't promote ancestors
         // in this engine (matches original fixColors). Root stays at
         // Identical/None — the "extra subtree" is shown by the per-row
-        // NotPresent colouring, not by an ancestor tint.
+        // NotPresent coloring, not by an ancestor tint.
     }
 };
 

--- a/tests/engine/test_engine.cpp
+++ b/tests/engine/test_engine.cpp
@@ -317,6 +317,77 @@ private slots:
     }
 
 
+    void asyncCompareEmitsPhases()
+    {
+        // compareAsync should emit phaseChanged at every algorithm
+        // boundary. FullPath: Building paths, Matching paths,
+        // Comparing values, Resolving colours. ParentChild: Indexing
+        // right tree, Pairing items, Resolving colours. Verify the
+        // FullPath path here — exact set + ordering.
+        QJsonModel left, right;
+        left.loadJson(R"({"a":1,"b":2})");
+        right.loadJson(R"({"a":1,"b":3})");
+        auto L = QSharedPointer<DiffNode>::create(JsonDiffEngine::snapshot(&left));
+        auto R = QSharedPointer<DiffNode>::create(JsonDiffEngine::snapshot(&right));
+
+        QThread t;
+        ThreadStopper stop{t};
+        JsonDiffEngine eng;
+        eng.moveToThread(&t);
+        t.start();
+
+        QStringList phases;
+        QObject::connect(&eng, &JsonDiffEngine::phaseChanged,
+                         [&](const QString &p) { phases.append(p); });
+
+        QSignalSpy finishedSpy(&eng, &JsonDiffEngine::finished);
+        QMetaObject::invokeMethod(&eng, "compareAsync", Qt::QueuedConnection,
+            Q_ARG(QSharedPointer<DiffNode>, L),
+            Q_ARG(QSharedPointer<DiffNode>, R),
+            Q_ARG(JsonDiffEngine::Mode, JsonDiffEngine::Mode::FullPath));
+        QVERIFY(finishedSpy.wait(2000));
+
+        QCOMPARE(phases, QStringList({
+            "Building paths",
+            "Matching paths",
+            "Comparing values",
+            "Resolving colours"
+        }));
+    }
+
+    void asyncCompareParentChildPhases()
+    {
+        // ParentChildPair: Indexing right tree, Pairing items, Resolving colours.
+        QJsonModel left, right;
+        left.loadJson(R"({"a":1})");
+        right.loadJson(R"({"a":1})");
+        auto L = QSharedPointer<DiffNode>::create(JsonDiffEngine::snapshot(&left));
+        auto R = QSharedPointer<DiffNode>::create(JsonDiffEngine::snapshot(&right));
+
+        QThread t;
+        ThreadStopper stop{t};
+        JsonDiffEngine eng;
+        eng.moveToThread(&t);
+        t.start();
+
+        QStringList phases;
+        QObject::connect(&eng, &JsonDiffEngine::phaseChanged,
+                         [&](const QString &p) { phases.append(p); });
+
+        QSignalSpy finishedSpy(&eng, &JsonDiffEngine::finished);
+        QMetaObject::invokeMethod(&eng, "compareAsync", Qt::QueuedConnection,
+            Q_ARG(QSharedPointer<DiffNode>, L),
+            Q_ARG(QSharedPointer<DiffNode>, R),
+            Q_ARG(JsonDiffEngine::Mode, JsonDiffEngine::Mode::ParentChildPair));
+        QVERIFY(finishedSpy.wait(2000));
+
+        QCOMPARE(phases, QStringList({
+            "Indexing right tree",
+            "Pairing items",
+            "Resolving colours"
+        }));
+    }
+
     void asyncCompareEmitsFinished()
     {
         JsonDiffEngine engine;
@@ -434,6 +505,546 @@ private slots:
         QModelIndex backToA = mr.itemFromIndex(aR)->idxRelation();
         QVERIFY(backToA.isValid());
         QCOMPARE(ml.itemFromIndex(backToA)->key(), QString("a"));
+    }
+
+    // ------------------------------------------------------------------
+    // Phase A: copyPeer + recomparePair
+    // Targeted edit-and-recompare — what the diff-edit overlay button
+    // will drive. Tests the snapshot-side logic in isolation; the
+    // widget-side glue lands in test_compare later.
+    // ------------------------------------------------------------------
+
+    void toJsonValueRoundTripsContainersAndScalars()
+    {
+        DiffNode root = makeRoot();
+        root.children.append(makeScalar("s", QJsonValue::String, "hi"));
+        root.children.append(makeScalar("n", QJsonValue::Double, "3.5"));
+        root.children.append(makeScalar("b", QJsonValue::Bool,   "true"));
+        DiffNode arr = makeContainer("arr", QJsonValue::Array);
+        arr.children.append(makeScalar("0", QJsonValue::Double, "1"));
+        arr.children.append(makeScalar("1", QJsonValue::Double, "2"));
+        root.children.append(arr);
+
+        QJsonValue v = JsonDiffEngine::toJsonValue(root);
+        QVERIFY(v.isObject());
+        QJsonObject obj = v.toObject();
+        QCOMPARE(obj.value("s").toString(), QString("hi"));
+        QCOMPARE(obj.value("n").toDouble(), 3.5);
+        QCOMPARE(obj.value("b").toBool(),   true);
+        QCOMPARE(obj.value("arr").toArray().size(), 2);
+        QCOMPARE(obj.value("arr").toArray()[0].toDouble(), 1.0);
+    }
+
+    void copyPeerOverwritesScalarKeepsKey()
+    {
+        DiffNode dst = makeScalar("k", QJsonValue::String, "old");
+        dst.color = DiffColorType::Huge;
+        DiffNode src = makeScalar("ignored", QJsonValue::Double, "42");
+
+        JsonDiffEngine::copyPeer(dst, src);
+
+        // Position-identifying key is preserved.
+        QCOMPARE(dst.key,   QString("k"));
+        // Everything else came from the peer.
+        QCOMPARE(dst.type,  QJsonValue::Double);
+        QCOMPARE(dst.value, QString("42"));
+        // color is deliberately untouched — recomparePair sets it.
+        QCOMPARE(dst.color, DiffColorType::Huge);
+    }
+
+    void recomparePairFlipsHugeLeafToIdenticalAfterCopy()
+    {
+        // {"a": "old"} vs {"a": "new"} — "a" is Huge on both sides.
+        DiffNode L = makeRoot();
+        L.children.append(makeScalar("a", QJsonValue::String, "old"));
+        DiffNode R = makeRoot();
+        R.children.append(makeScalar("a", QJsonValue::String, "new"));
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(L.children[0].color, DiffColorType::Huge);
+
+        // Simulate the "copy from peer" click on the left side.
+        JsonDiffEngine::copyPeer(L.children[0], R.children[0]);
+        QList<int> path{0};
+        JsonDiffEngine::recomparePair(L, path, R, path, JsonDiffEngine::Mode::FullPath);
+
+        QCOMPARE(L.children[0].color, DiffColorType::Identical);
+        QCOMPARE(R.children[0].color, DiffColorType::Identical);
+    }
+
+    void recomparePairDemotesAncestorModerateToIdentical()
+    {
+        // {"a": {"b": "old"}} vs {"a": {"b": "new"}}
+        //  b -> Huge, a -> Moderate before edit.
+        // After copyPeer + recomparePair on b: both b -> Identical, and
+        // ancestor "a" should demote back to Identical (no other diffs).
+        auto build = [](const QString &leaf) {
+            DiffNode root = makeRoot();
+            DiffNode a = makeContainer("a", QJsonValue::Object);
+            a.children.append(makeScalar("b", QJsonValue::String, leaf));
+            root.children.append(a);
+            return root;
+        };
+        DiffNode L = build("old");
+        DiffNode R = build("new");
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(L.children[0].color,             DiffColorType::Moderate);
+        QCOMPARE(L.children[0].children[0].color, DiffColorType::Huge);
+
+        JsonDiffEngine::copyPeer(L.children[0].children[0],
+                                 R.children[0].children[0]);
+        QList<int> path{0, 0};
+        JsonDiffEngine::recomparePair(L, path, R, path, JsonDiffEngine::Mode::FullPath);
+
+        QCOMPARE(L.children[0].children[0].color, DiffColorType::Identical);
+        QCOMPARE(L.children[0].color,             DiffColorType::Identical);
+        QCOMPARE(R.children[0].children[0].color, DiffColorType::Identical);
+        QCOMPARE(R.children[0].color,             DiffColorType::Identical);
+    }
+
+    void recomparePairKeepsAncestorModerateWhenSiblingStillDiffers()
+    {
+        // {"a": {"b": "old", "c": "x"}} vs {"a": {"b": "new", "c": "y"}}
+        // Both b and c are Huge, a is Moderate.
+        // Edit only b. a stays Moderate because c is still Huge.
+        auto build = [](const QString &b, const QString &c) {
+            DiffNode root = makeRoot();
+            DiffNode a = makeContainer("a", QJsonValue::Object);
+            a.children.append(makeScalar("b", QJsonValue::String, b));
+            a.children.append(makeScalar("c", QJsonValue::String, c));
+            root.children.append(a);
+            return root;
+        };
+        DiffNode L = build("old", "x");
+        DiffNode R = build("new", "y");
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(L.children[0].color, DiffColorType::Moderate);
+
+        // Resolve only b.
+        JsonDiffEngine::copyPeer(L.children[0].children[0],
+                                 R.children[0].children[0]);
+        QList<int> path{0, 0};
+        JsonDiffEngine::recomparePair(L, path, R, path, JsonDiffEngine::Mode::FullPath);
+
+        QCOMPARE(L.children[0].children[0].color, DiffColorType::Identical);
+        // c is still Huge, so a is still Moderate.
+        QCOMPARE(L.children[0].children[1].color, DiffColorType::Huge);
+        QCOMPARE(L.children[0].color,             DiffColorType::Moderate);
+    }
+
+    void recomparePairPreservesRelationPath()
+    {
+        // Cross-link must still resolve after the edit (the matched
+        // peer is at the same path — copying value doesn't change
+        // tree shape).
+        DiffNode L = makeRoot();
+        L.children.append(makeScalar("k", QJsonValue::String, "old"));
+        DiffNode R = makeRoot();
+        R.children.append(makeScalar("k", QJsonValue::String, "new"));
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+
+        const QList<int> savedRel = L.children[0].relationPath;
+        QVERIFY(!savedRel.isEmpty());
+
+        JsonDiffEngine::copyPeer(L.children[0], R.children[0]);
+        QList<int> path{0};
+        JsonDiffEngine::recomparePair(L, path, R, path, JsonDiffEngine::Mode::FullPath);
+
+        QCOMPARE(L.children[0].relationPath, savedRel);
+    }
+
+    void recomparePairHandlesEmptyPath()
+    {
+        // Path = {} means the root itself. Should be a no-op, not crash.
+        DiffNode L = makeRoot();
+        DiffNode R = makeRoot();
+        L.children.append(makeScalar("a", QJsonValue::Double, "1"));
+        R.children.append(makeScalar("a", QJsonValue::Double, "1"));
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+
+        JsonDiffEngine::recomparePair(L, {}, R, {}, JsonDiffEngine::Mode::FullPath);
+
+        // Children below the root weren't touched.
+        QCOMPARE(L.children[0].color, DiffColorType::Identical);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase B — resolveDstParentPath, insertPeer, removePeer
+    // ------------------------------------------------------------------
+
+    void resolveDstParentRejectsRootPath()
+    {
+        DiffNode L = makeRoot();
+        QList<int> out;
+        QVERIFY(!JsonDiffEngine::resolveDstParentPath(L, {}, out));
+    }
+
+    void resolveDstParentRootChildMirrorsRoot()
+    {
+        // Top-level NotPresent: src parent is root → dst parent is the
+        // OTHER root, which we encode as an empty path.
+        DiffNode L = makeRoot();
+        L.children.append(makeScalar("only_left", QJsonValue::String, "x"));
+        QList<int> out;
+        QVERIFY(JsonDiffEngine::resolveDstParentPath(L, {0}, out));
+        QVERIFY(out.isEmpty());
+    }
+
+    void resolveDstParentNestedUsesParentRelationPath()
+    {
+        // {"a":{"b":1,"only_left":2}} vs {"a":{"b":1}}
+        // src.a is Identical/Moderate, src.only_left is NotPresent.
+        // resolveDstParentPath returns the dst path to "a".
+        DiffNode L = makeRoot();
+        DiffNode a_l = makeContainer("a", QJsonValue::Object);
+        a_l.children.append(makeScalar("b", QJsonValue::Double, "1"));
+        a_l.children.append(makeScalar("only_left", QJsonValue::Double, "2"));
+        L.children.append(a_l);
+
+        DiffNode R = makeRoot();
+        DiffNode a_r = makeContainer("a", QJsonValue::Object);
+        a_r.children.append(makeScalar("b", QJsonValue::Double, "1"));
+        R.children.append(a_r);
+
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(L.children[0].children[1].color, DiffColorType::NotPresent);
+
+        QList<int> out;
+        QVERIFY(JsonDiffEngine::resolveDstParentPath(L, {0, 1}, out));
+        QCOMPARE(out, (QList<int>{0}));   // R.children[0] is "a"
+    }
+
+    void resolveDstParentRejectsWhenParentAlsoNotPresent()
+    {
+        // {"a":{"b":1}} vs {} — "a" doesn't exist on right; both "a"
+        // and "a/b" are NotPresent on left. Pushing "a/b" must fail —
+        // its parent has no peer to insert into.
+        DiffNode L = makeRoot();
+        DiffNode a_l = makeContainer("a", QJsonValue::Object);
+        a_l.children.append(makeScalar("b", QJsonValue::Double, "1"));
+        L.children.append(a_l);
+        DiffNode R = makeRoot();
+
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QList<int> out;
+        QVERIFY(!JsonDiffEngine::resolveDstParentPath(L, {0, 0}, out));
+    }
+
+    void insertPeerAppendsAndLinksWholeSubtree()
+    {
+        // {"a":{"x":1}, "extra":{"deep":42}} vs {"a":{"x":1}}.
+        // "extra" is NotPresent on left. After insertPeer, it appears
+        // on right; both "extra" and "extra.deep" become Identical and
+        // cross-linked.
+        DiffNode L = makeRoot();
+        DiffNode a_l = makeContainer("a", QJsonValue::Object);
+        a_l.children.append(makeScalar("x", QJsonValue::Double, "1"));
+        L.children.append(a_l);
+        DiffNode extra = makeContainer("extra", QJsonValue::Object);
+        extra.children.append(makeScalar("deep", QJsonValue::Double, "42"));
+        L.children.append(extra);
+
+        DiffNode R = makeRoot();
+        DiffNode a_r = makeContainer("a", QJsonValue::Object);
+        a_r.children.append(makeScalar("x", QJsonValue::Double, "1"));
+        R.children.append(a_r);
+
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(L.children[1].color, DiffColorType::NotPresent);
+
+        QList<int> dstPath = JsonDiffEngine::insertPeer(L, {1}, R, {},
+                                                       JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(dstPath, (QList<int>{1}));
+        // Top of inserted subtree.
+        QCOMPARE(R.children[1].key,                  QString("extra"));
+        QCOMPARE(R.children[1].color,                DiffColorType::Identical);
+        QCOMPARE(R.children[1].relationPath,         (QList<int>{1}));
+        // Interior — must also be cross-linked.
+        QCOMPARE(R.children[1].children[0].key,       QString("deep"));
+        QCOMPARE(R.children[1].children[0].color,     DiffColorType::Identical);
+        QCOMPARE(R.children[1].children[0].relationPath, (QList<int>{1, 0}));
+        // Source side flipped from NotPresent → Identical.
+        QCOMPARE(L.children[1].color,                DiffColorType::Identical);
+        QCOMPARE(L.children[1].relationPath,         (QList<int>{1}));
+    }
+
+    void insertPeerAppendToArrayUsesIndexKey()
+    {
+        // {"arr":[10,20,30]} vs {"arr":[10,20]}: index 2 (value 30)
+        // is NotPresent on left. After push, it appears at index 2 on
+        // right with key "2".
+        DiffNode L = makeRoot();
+        DiffNode arr_l = makeContainer("arr", QJsonValue::Array);
+        arr_l.children.append(makeScalar("0", QJsonValue::Double, "10"));
+        arr_l.children.append(makeScalar("1", QJsonValue::Double, "20"));
+        arr_l.children.append(makeScalar("2", QJsonValue::Double, "30"));
+        L.children.append(arr_l);
+
+        DiffNode R = makeRoot();
+        DiffNode arr_r = makeContainer("arr", QJsonValue::Array);
+        arr_r.children.append(makeScalar("0", QJsonValue::Double, "10"));
+        arr_r.children.append(makeScalar("1", QJsonValue::Double, "20"));
+        R.children.append(arr_r);
+
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(L.children[0].children[2].color, DiffColorType::NotPresent);
+
+        QList<int> dstPath = JsonDiffEngine::insertPeer(L, {0, 2}, R, {0},
+                                                       JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(dstPath, (QList<int>{0, 2}));
+        QCOMPARE(R.children[0].children.size(), 3);
+        QCOMPARE(R.children[0].children[2].key,   QString("2"));   // index-keyed
+        QCOMPARE(R.children[0].children[2].value, QString("30"));
+        QCOMPARE(R.children[0].children[2].color, DiffColorType::Identical);
+    }
+
+    void removePeerOrphansPairedSibling()
+    {
+        // {"a":1,"b":2,"c":3} vs {"a":1,"b":2,"c":3}: all Identical.
+        // Delete "b" on the left. Right's "b" must become NotPresent
+        // and right's "c" must shift its relationPath from {2} to {1}.
+        DiffNode L = makeRoot();
+        L.children.append(makeScalar("a", QJsonValue::Double, "1"));
+        L.children.append(makeScalar("b", QJsonValue::Double, "2"));
+        L.children.append(makeScalar("c", QJsonValue::Double, "3"));
+        DiffNode R = makeRoot();
+        R.children.append(makeScalar("a", QJsonValue::Double, "1"));
+        R.children.append(makeScalar("b", QJsonValue::Double, "2"));
+        R.children.append(makeScalar("c", QJsonValue::Double, "3"));
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(R.children[2].relationPath, (QList<int>{2}));
+
+        QVERIFY(JsonDiffEngine::removePeer(L, {1}, R,
+                                           JsonDiffEngine::Mode::FullPath));
+        QCOMPARE(L.children.size(), 2);
+        QCOMPARE(L.children[0].key, QString("a"));
+        QCOMPARE(L.children[1].key, QString("c"));
+        // Right's "b" was paired → now orphaned to NotPresent.
+        QCOMPARE(R.children[1].key,           QString("b"));
+        QCOMPARE(R.children[1].color,         DiffColorType::NotPresent);
+        QVERIFY (R.children[1].relationPath.isEmpty());
+        // Right's "c" used to point at L.children[2]; now it must
+        // point at L.children[1] (the slot vacated by the shift).
+        QCOMPARE(R.children[2].relationPath, (QList<int>{1}));
+    }
+
+    void removePeerNotPresentLeafHasNoOrphan()
+    {
+        // {"a":1,"only_left":2} vs {"a":1}. only_left is NotPresent on
+        // left and has no peer. Deleting it just removes it; right side
+        // is left untouched.
+        DiffNode L = makeRoot();
+        L.children.append(makeScalar("a",         QJsonValue::Double, "1"));
+        L.children.append(makeScalar("only_left", QJsonValue::Double, "2"));
+        DiffNode R = makeRoot();
+        R.children.append(makeScalar("a", QJsonValue::Double, "1"));
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(L.children[1].color, DiffColorType::NotPresent);
+
+        QVERIFY(JsonDiffEngine::removePeer(L, {1}, R,
+                                           JsonDiffEngine::Mode::FullPath));
+        QCOMPARE(L.children.size(), 1);
+        QCOMPARE(R.children.size(), 1);
+        QCOMPARE(R.children[0].color,        DiffColorType::Identical);
+        QCOMPARE(R.children[0].relationPath, (QList<int>{0}));
+    }
+
+    void removePeerRejectsRoot()
+    {
+        DiffNode L = makeRoot();
+        DiffNode R = makeRoot();
+        QVERIFY(!JsonDiffEngine::removePeer(L, {}, R,
+                                            JsonDiffEngine::Mode::FullPath));
+    }
+
+    void removePeerArrayRenumbersSurvivorKeys()
+    {
+        // Both sides have a 3-element array. Delete the middle element
+        // on the left — survivors' keys must shift "0","2" → "0","1"
+        // so a subsequent FullPath compare matches by position.
+        DiffNode L = makeRoot();
+        DiffNode arr_l = makeContainer("arr", QJsonValue::Array);
+        arr_l.children.append(makeScalar("0", QJsonValue::Double, "10"));
+        arr_l.children.append(makeScalar("1", QJsonValue::Double, "20"));
+        arr_l.children.append(makeScalar("2", QJsonValue::Double, "30"));
+        L.children.append(arr_l);
+
+        DiffNode R = makeRoot();
+        DiffNode arr_r = makeContainer("arr", QJsonValue::Array);
+        arr_r.children.append(makeScalar("0", QJsonValue::Double, "10"));
+        arr_r.children.append(makeScalar("1", QJsonValue::Double, "20"));
+        arr_r.children.append(makeScalar("2", QJsonValue::Double, "30"));
+        R.children.append(arr_r);
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+
+        QVERIFY(JsonDiffEngine::removePeer(L, {0, 1}, R,
+                                           JsonDiffEngine::Mode::FullPath));
+        QCOMPARE(L.children[0].children.size(), 2);
+        QCOMPARE(L.children[0].children[0].key, QString("0"));
+        QCOMPARE(L.children[0].children[1].key, QString("1"));   // renumbered
+        // Values follow the renumber correctly.
+        QCOMPARE(L.children[0].children[1].value, QString("30"));
+    }
+
+    void removePeerObjectKeysUnchanged()
+    {
+        // Object children carry meaningful keys — deletion must NOT
+        // touch survivor keys.
+        DiffNode L = makeRoot();
+        L.children.append(makeScalar("a", QJsonValue::Double, "1"));
+        L.children.append(makeScalar("b", QJsonValue::Double, "2"));
+        L.children.append(makeScalar("c", QJsonValue::Double, "3"));
+        DiffNode R = makeRoot();
+        R.children.append(makeScalar("a", QJsonValue::Double, "1"));
+        R.children.append(makeScalar("b", QJsonValue::Double, "2"));
+        R.children.append(makeScalar("c", QJsonValue::Double, "3"));
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+
+        QVERIFY(JsonDiffEngine::removePeer(L, {1}, R,
+                                           JsonDiffEngine::Mode::FullPath));
+        QCOMPARE(L.children[0].key, QString("a"));
+        QCOMPARE(L.children[1].key, QString("c"));   // NOT "b"
+    }
+
+    void detachPairBothSidesGoNotPresent()
+    {
+        // Identical pair → detach → both sides NotPresent, no peer links.
+        DiffNode L = makeRoot();
+        L.children.append(makeScalar("k", QJsonValue::String, "v"));
+        DiffNode R = makeRoot();
+        R.children.append(makeScalar("k", QJsonValue::String, "v"));
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(L.children[0].color, DiffColorType::Identical);
+
+        QVERIFY(JsonDiffEngine::detachPair(L, {0}, R,
+                                           JsonDiffEngine::Mode::FullPath));
+        QCOMPARE(L.children[0].color,        DiffColorType::NotPresent);
+        QCOMPARE(R.children[0].color,        DiffColorType::NotPresent);
+        QVERIFY (L.children[0].relationPath.isEmpty());
+        QVERIFY (R.children[0].relationPath.isEmpty());
+    }
+
+    void detachPairRejectsRootPath()
+    {
+        DiffNode L = makeRoot();
+        DiffNode R = makeRoot();
+        QVERIFY(!JsonDiffEngine::detachPair(L, {}, R,
+                                            JsonDiffEngine::Mode::FullPath));
+    }
+
+    void resnapshotSubtreeReplacesChildrenFromModel()
+    {
+        // Build a real model: {"k":{"x":1,"y":2}}, take a snapshot,
+        // then mutate the model in place (remove a child) and confirm
+        // resnapshotSubtree pulls in the new shape.
+        QJsonModel m;
+        m.loadJson(R"({"k":{"x":1,"y":2}})");
+        DiffNode mySnap = JsonDiffEngine::snapshot(&m);
+        QCOMPARE(mySnap.children[0].children.size(), 2);
+
+        // Edit the model: drop "y" from k's children.
+        m.setEditable(true);
+        QModelIndex kIdx = m.index(0, 0, QModelIndex());
+        QModelIndex yIdx;
+        for (int i = 0; i < m.rowCount(kIdx); ++i)
+        {
+            QModelIndex c = m.index(i, 0, kIdx);
+            if (m.itemFromIndex(c)->key() == "y") { yIdx = c; break; }
+        }
+        QVERIFY(m.removeRowAt(yIdx));
+
+        DiffNode peerSnap;            // empty peer just for the API
+        QVERIFY(JsonDiffEngine::resnapshotSubtree(mySnap, {0}, &m, peerSnap));
+        QCOMPARE(mySnap.children[0].children.size(), 1);
+        QCOMPARE(mySnap.children[0].children[0].key,  QString("x"));
+        // Re-snapshotted children default to NotPresent (no peer).
+        QCOMPARE(mySnap.children[0].children[0].color,
+                 DiffColorType::NotPresent);
+    }
+
+    void resnapshotSubtreeOrphansPeerDescendants()
+    {
+        // {"k":{"x":1}} == {"k":{"x":1}}: identical with cross-links
+        // on root.children[0].children[0]. After resnapshotSubtree on
+        // left's "k", peer's "x" should be orphaned (its relationPath
+        // pointed INTO the subtree we just replaced).
+        QJsonModel ml, mr;
+        ml.loadJson(R"({"k":{"x":1}})");
+        mr.loadJson(R"({"k":{"x":1}})");
+        DiffNode L = JsonDiffEngine::snapshot(&ml);
+        DiffNode R = JsonDiffEngine::snapshot(&mr);
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(R.children[0].children[0].color,        DiffColorType::Identical);
+        QCOMPARE(R.children[0].children[0].relationPath, (QList<int>{0, 0}));
+
+        QVERIFY(JsonDiffEngine::resnapshotSubtree(L, {0}, &ml, R));
+
+        // Peer of L[0] (R[0]) is left intact — recomparePair handles
+        // its colour after this call. Its DESCENDANT was orphaned.
+        QCOMPARE(R.children[0].children[0].color,        DiffColorType::NotPresent);
+        QVERIFY (R.children[0].children[0].relationPath.isEmpty());
+        // The pair at the top of the subtree is untouched here.
+        QCOMPARE(R.children[0].relationPath,             (QList<int>{0}));
+    }
+
+    void resnapshotSubtreeRejectsEmptyPath()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"a":1})");
+        DiffNode mySnap = JsonDiffEngine::snapshot(&m);
+        DiffNode peerSnap;
+        QVERIFY(!JsonDiffEngine::resnapshotSubtree(mySnap, {}, &m, peerSnap));
+    }
+
+    void detachPairUnpairedLeafNoOpsOnPeer()
+    {
+        // NotPresent leaf has no peer to touch on the other side; the
+        // function still updates this side (re-marks NotPresent, same).
+        DiffNode L = makeRoot();
+        L.children.append(makeScalar("only_left", QJsonValue::Double, "1"));
+        DiffNode R = makeRoot();
+        R.children.append(makeScalar("only_right", QJsonValue::Double, "2"));
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+        QCOMPARE(L.children[0].color, DiffColorType::NotPresent);
+
+        QVERIFY(JsonDiffEngine::detachPair(L, {0}, R,
+                                           JsonDiffEngine::Mode::FullPath));
+        QCOMPARE(L.children[0].color, DiffColorType::NotPresent);
+        QCOMPARE(R.children[0].color, DiffColorType::NotPresent);
+    }
+
+    void removePeerSubtreeOrphansAllDescendants()
+    {
+        // {"keep":1,"big":{"x":1,"y":2}} vs {"keep":1,"big":{"x":1,"y":2}}.
+        // Delete "big" on left. Right's "big", "big.x", "big.y" all go
+        // NotPresent.
+        DiffNode L = makeRoot();
+        L.children.append(makeScalar("keep", QJsonValue::Double, "1"));
+        DiffNode big_l = makeContainer("big", QJsonValue::Object);
+        big_l.children.append(makeScalar("x", QJsonValue::Double, "1"));
+        big_l.children.append(makeScalar("y", QJsonValue::Double, "2"));
+        L.children.append(big_l);
+
+        DiffNode R = makeRoot();
+        R.children.append(makeScalar("keep", QJsonValue::Double, "1"));
+        DiffNode big_r = makeContainer("big", QJsonValue::Object);
+        big_r.children.append(makeScalar("x", QJsonValue::Double, "1"));
+        big_r.children.append(makeScalar("y", QJsonValue::Double, "2"));
+        R.children.append(big_r);
+
+        JsonDiffEngine::compare(L, R, JsonDiffEngine::Mode::FullPath);
+
+        QVERIFY(JsonDiffEngine::removePeer(L, {1}, R,
+                                           JsonDiffEngine::Mode::FullPath));
+        QCOMPARE(R.children[1].color,                DiffColorType::NotPresent);
+        QCOMPARE(R.children[1].children[0].color,    DiffColorType::NotPresent);
+        QCOMPARE(R.children[1].children[1].color,    DiffColorType::NotPresent);
+        QVERIFY (R.children[1].relationPath.isEmpty());
+        QVERIFY (R.children[1].children[0].relationPath.isEmpty());
+        QVERIFY (R.children[1].children[1].relationPath.isEmpty());
+        // Root's color: NotPresent descendants don't promote ancestors
+        // in this engine (matches original fixColors). Root stays at
+        // Identical/None — the "extra subtree" is shown by the per-row
+        // NotPresent colouring, not by an ancestor tint.
     }
 };
 

--- a/translations/qtjsondiff_en_US.ts
+++ b/translations/qtjsondiff_en_US.ts
@@ -73,119 +73,181 @@ Available styles:
     </message>
     <message>
         <location filename="../preferences/preferencesdialog.ui" line="47"/>
-        <location filename="../preferences/preferencesdialog.ui" line="78"/>
+        <location filename="../preferences/preferencesdialog.ui" line="94"/>
         <source>Colors</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../preferences/preferencesdialog.ui" line="55"/>
-        <location filename="../preferences/preferencesdialog.ui" line="293"/>
+        <location filename="../preferences/preferencesdialog.ui" line="309"/>
         <source>Layout</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../preferences/preferencesdialog.ui" line="63"/>
+        <location filename="../preferences/preferencesdialog.ui" line="431"/>
+        <source>Style</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="71"/>
+        <location filename="../preferences/preferencesdialog.ui" line="508"/>
+        <source>JSON Editing</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="79"/>
         <source>Keyboard Shortcuts</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="84"/>
+        <location filename="../preferences/preferencesdialog.ui" line="100"/>
         <source>Tree View</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="90"/>
+        <location filename="../preferences/preferencesdialog.ui" line="106"/>
         <source>Identical Diff:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="110"/>
+        <location filename="../preferences/preferencesdialog.ui" line="126"/>
         <source>Moderate Diff:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="130"/>
+        <location filename="../preferences/preferencesdialog.ui" line="146"/>
         <source>Huge Diff:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="150"/>
+        <location filename="../preferences/preferencesdialog.ui" line="166"/>
         <source>Not Present Diff:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="170"/>
+        <location filename="../preferences/preferencesdialog.ui" line="186"/>
         <source>Transparency:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="187"/>
+        <location filename="../preferences/preferencesdialog.ui" line="203"/>
         <source>Text View</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="193"/>
+        <location filename="../preferences/preferencesdialog.ui" line="209"/>
         <source>Keywords:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="213"/>
+        <location filename="../preferences/preferencesdialog.ui" line="229"/>
         <source>JSON Keys:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="264"/>
-        <location filename="../preferences/preferencesdialog.ui" line="449"/>
+        <location filename="../preferences/preferencesdialog.ui" line="280"/>
+        <location filename="../preferences/preferencesdialog.ui" line="588"/>
         <source>Restore Defaults</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="350"/>
+        <location filename="../preferences/preferencesdialog.ui" line="366"/>
         <source>Tabs Position</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="358"/>
+        <location filename="../preferences/preferencesdialog.ui" line="374"/>
         <source>North</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="371"/>
+        <location filename="../preferences/preferencesdialog.ui" line="387"/>
         <source>South</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="381"/>
+        <location filename="../preferences/preferencesdialog.ui" line="397"/>
         <source>West</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="391"/>
+        <location filename="../preferences/preferencesdialog.ui" line="407"/>
         <source>East</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="312"/>
+        <location filename="../preferences/preferencesdialog.ui" line="439"/>
+        <source>Application style:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="446"/>
+        <source>Pick the Qt style used by the whole application. &quot;Default&quot; lets Qt choose the platform default.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="468"/>
+        <source>Style change takes effect after restart.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="478"/>
+        <source>Use styled tree view</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="481"/>
+        <source>When on, JSON tree views get custom branch icons and hover/select gradients from qss/qjsontreeview.qss. Off (default) uses the plain platform look.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="514"/>
+        <source>Enable inline editing in single-tree view</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="517"/>
+        <source>When on, keys, types and values can be edited inline on the single-tree tab. Add/Delete row actions also appear in the context menu.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="524"/>
+        <source>Enable inline editing in diff view</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="527"/>
+        <source>When on, both diff trees become editable. Push arrows resolve Huge differences and copy NotPresent rows to the other side; Delete here removes the selected row.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="328"/>
         <source>View Button Position</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="320"/>
+        <location filename="../preferences/preferencesdialog.ui" line="336"/>
         <source>Show Bottom</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="333"/>
+        <location filename="../preferences/preferencesdialog.ui" line="349"/>
         <source>Top Inline only</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.cpp" line="86"/>
+        <location filename="../preferences/preferencesdialog.cpp" line="83"/>
+        <source>Default</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.cpp" line="117"/>
         <source>Action</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.cpp" line="86"/>
+        <location filename="../preferences/preferencesdialog.cpp" line="117"/>
         <source>Shortcut</source>
         <translation></translation>
     </message>
@@ -203,15 +265,15 @@ Available styles:
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="141"/>
-        <location filename="../qjsoncontainer.cpp" line="884"/>
+        <location filename="../qjsoncontainer.cpp" line="145"/>
+        <location filename="../qjsoncontainer.cpp" line="1016"/>
         <source>Show Json Text</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="125"/>
-        <location filename="../qjsoncontainer.cpp" line="126"/>
-        <location filename="../qjsoncontainer.cpp" line="1098"/>
+        <location filename="../qjsoncontainer.cpp" line="129"/>
+        <location filename="../qjsoncontainer.cpp" line="130"/>
+        <location filename="../qjsoncontainer.cpp" line="1230"/>
         <source>Expand</source>
         <translation></translation>
     </message>
@@ -246,89 +308,99 @@ Available styles:
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="130"/>
-        <source>Sort</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="148"/>
-        <source>Serach for...</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="149"/>
-        <source>Enter text and press enter to search</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="155"/>
-        <source>Find Next</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="165"/>
-        <source>Check to make case sensitive</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="199"/>
-        <source>Select file or use URL to load json data</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="200"/>
-        <source>Select file or use full path/URL and hit enter to load json data</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="854"/>
-        <location filename="../qjsoncontainer.cpp" line="1714"/>
-        <source>Start of json has been reached! Next item will be from the end</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="854"/>
-        <location filename="../qjsoncontainer.cpp" line="1714"/>
-        <source>End of json has been reached! Next item will be from the start</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="864"/>
-        <source>&lt;b&gt;&lt;font &quot;color&quot;=red&gt;Text Not Found!&lt;/font&gt;&lt;/b&gt;</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="895"/>
-        <source>Show Json View</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="910"/>
-        <source>Open File</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="911"/>
-        <source>Files (*.json *.jsn *.txt);;All Files (*)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="160"/>
-        <source>Find Previous</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../qjsoncontainer.cpp" line="208"/>
-        <source>Reload</source>
+        <location filename="../qjsoncontainer.cpp" line="44"/>
+        <source>Add child</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../qjsoncontainer.cpp" line="45"/>
+        <source>Delete row</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="134"/>
+        <source>Sort</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="152"/>
+        <source>Serach for...</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="153"/>
+        <source>Enter text and press enter to search</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="159"/>
+        <source>Find Next</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="169"/>
+        <source>Check to make case sensitive</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="203"/>
+        <source>Select file or use URL to load json data</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="204"/>
+        <source>Select file or use full path/URL and hit enter to load json data</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="986"/>
+        <location filename="../qjsoncontainer.cpp" line="1846"/>
+        <source>Start of json has been reached! Next item will be from the end</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="986"/>
+        <location filename="../qjsoncontainer.cpp" line="1846"/>
+        <source>End of json has been reached! Next item will be from the start</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="996"/>
+        <source>&lt;b&gt;&lt;font &quot;color&quot;=red&gt;Text Not Found!&lt;/font&gt;&lt;/b&gt;</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="1027"/>
+        <source>Show Json View</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="1042"/>
+        <source>Open File</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="1043"/>
+        <source>Files (*.json *.jsn *.txt);;All Files (*)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="164"/>
+        <source>Find Previous</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="212"/>
+        <source>Reload</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="49"/>
         <source>Expand Selected</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="46"/>
+        <location filename="../qjsoncontainer.cpp" line="50"/>
         <source>Collapse Selected</source>
         <translation></translation>
     </message>
@@ -343,100 +415,100 @@ Available styles:
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="204"/>
+        <location filename="../qjsoncontainer.cpp" line="208"/>
         <source>Open file</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="142"/>
+        <location filename="../qjsoncontainer.cpp" line="146"/>
         <source>Switch between view modes</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="483"/>
+        <location filename="../qjsoncontainer.cpp" line="589"/>
         <source>-&gt;|</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="485"/>
-        <location filename="../qjsoncontainer.cpp" line="486"/>
+        <location filename="../qjsoncontainer.cpp" line="591"/>
+        <location filename="../qjsoncontainer.cpp" line="592"/>
         <source>Go to Next Diff</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="488"/>
+        <location filename="../qjsoncontainer.cpp" line="594"/>
         <source>|&lt;-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="490"/>
-        <location filename="../qjsoncontainer.cpp" line="491"/>
+        <location filename="../qjsoncontainer.cpp" line="596"/>
+        <location filename="../qjsoncontainer.cpp" line="597"/>
         <source>Go to Previous Diff</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="1727"/>
+        <location filename="../qjsoncontainer.cpp" line="1859"/>
         <source>&lt;b&gt;&lt;font &quot;color&quot;=green&gt;Documents identical!&lt;/font&gt;&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="1732"/>
+        <location filename="../qjsoncontainer.cpp" line="1864"/>
         <source>&lt;b&gt;&lt;font &quot;color&quot;=yellow&gt;Start Comparison!&lt;/font&gt;&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="131"/>
+        <location filename="../qjsoncontainer.cpp" line="135"/>
         <source>Sort objects inside array
 It can be helpful for comparison when order does not relevant</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="136"/>
+        <location filename="../qjsoncontainer.cpp" line="140"/>
         <source>Switch View</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="137"/>
+        <location filename="../qjsoncontainer.cpp" line="141"/>
         <source>Switch between tree/text view</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="152"/>
+        <location filename="../qjsoncontainer.cpp" line="156"/>
         <source>&gt;&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="153"/>
+        <location filename="../qjsoncontainer.cpp" line="157"/>
         <source>Search Next</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="157"/>
+        <location filename="../qjsoncontainer.cpp" line="161"/>
         <source>&lt;&lt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="163"/>
+        <location filename="../qjsoncontainer.cpp" line="167"/>
         <source>Search case sensetive</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="974"/>
+        <location filename="../qjsoncontainer.cpp" line="1106"/>
         <source>&lt;b&gt;&lt;font color=&apos;red&apos;&gt;JSON parse error:&lt;/font&gt;&lt;/b&gt; </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="1089"/>
+        <location filename="../qjsoncontainer.cpp" line="1221"/>
         <source>Collapse</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="158"/>
+        <location filename="../qjsoncontainer.cpp" line="162"/>
         <source>Search Previous</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="494"/>
+        <location filename="../qjsoncontainer.cpp" line="600"/>
         <source>Amount of Differences (without root objects/arrays, means values only)</source>
         <translation></translation>
     </message>
@@ -444,47 +516,119 @@ It can be helpful for comparison when order does not relevant</source>
 <context>
     <name>QJsonDiff</name>
     <message>
-        <location filename="../qjsondiff.cpp" line="65"/>
+        <location filename="../qjsondiff.cpp" line="71"/>
         <source>Compare</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="66"/>
+        <location filename="../qjsondiff.cpp" line="72"/>
         <source>Start comparison (ALT+C)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="70"/>
+        <location filename="../qjsondiff.cpp" line="76"/>
         <source>Sync Scrolls</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="74"/>
+        <location filename="../qjsondiff.cpp" line="80"/>
         <source>Use Full Path</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="76"/>
+        <location filename="../qjsondiff.cpp" line="82"/>
         <source>Otherwise try to find child+parent pair anywhere in JSON tree</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../qjsondiff.cpp" line="319"/>
+        <source>Building paths</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="321"/>
+        <source>Matching paths</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="323"/>
+        <source>Comparing values</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="325"/>
+        <source>Indexing right tree</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="327"/>
+        <source>Pairing items</source>
+        <translation></translation>
+    </message>
+    <message>
         <location filename="../qjsondiff.cpp" line="329"/>
+        <source>Resolving colors</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="424"/>
         <source>Comparing JSON</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="330"/>
-        <source>Running comparison...</source>
+        <location filename="../qjsondiff.cpp" line="436"/>
+        <source>Starting</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="331"/>
+        <location filename="../qjsondiff.cpp" line="505"/>
+        <source>Running comparison</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="510"/>
+        <source>%1… (%2s)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="685"/>
+        <source>Push to right</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="686"/>
+        <source>Push selected row into the matching row on the right side (overwrites)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="692"/>
+        <source>Push to left</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="693"/>
+        <source>Push selected row into the matching row on the left side (overwrites)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="700"/>
+        <location filename="../qjsondiff.cpp" line="707"/>
+        <source>Delete here</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="701"/>
+        <location filename="../qjsondiff.cpp" line="708"/>
+        <source>Remove the selected row from this side. If it had a peer on the other side, the peer becomes NotPresent.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="425"/>
         <source>Cancel</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="71"/>
+        <location filename="../qjsondiff.cpp" line="77"/>
         <source>Try to sync left and right scrolling areas</source>
         <translation></translation>
     </message>
@@ -492,17 +636,17 @@ It can be helpful for comparison when order does not relevant</source>
 <context>
     <name>QJsonModel</name>
     <message>
-        <location filename="../qjsonmodel.cpp" line="40"/>
+        <location filename="../qjsonmodel.cpp" line="45"/>
         <source>Name</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsonmodel.cpp" line="41"/>
+        <location filename="../qjsonmodel.cpp" line="46"/>
         <source>Type</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qjsonmodel.cpp" line="42"/>
+        <location filename="../qjsonmodel.cpp" line="47"/>
         <source>Value</source>
         <translation></translation>
     </message>

--- a/translations/qtjsondiff_uk_UA.ts
+++ b/translations/qtjsondiff_uk_UA.ts
@@ -75,119 +75,181 @@ Available styles:
     </message>
     <message>
         <location filename="../preferences/preferencesdialog.ui" line="47"/>
-        <location filename="../preferences/preferencesdialog.ui" line="78"/>
+        <location filename="../preferences/preferencesdialog.ui" line="94"/>
         <source>Colors</source>
         <translation>Кольори</translation>
     </message>
     <message>
         <location filename="../preferences/preferencesdialog.ui" line="55"/>
-        <location filename="../preferences/preferencesdialog.ui" line="293"/>
+        <location filename="../preferences/preferencesdialog.ui" line="309"/>
         <source>Layout</source>
         <translation>Вигляд</translation>
     </message>
     <message>
         <location filename="../preferences/preferencesdialog.ui" line="63"/>
+        <location filename="../preferences/preferencesdialog.ui" line="431"/>
+        <source>Style</source>
+        <translation>Стиль</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="71"/>
+        <location filename="../preferences/preferencesdialog.ui" line="508"/>
+        <source>JSON Editing</source>
+        <translation>JSON  редагування</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="79"/>
         <source>Keyboard Shortcuts</source>
         <translation>Комбінації клавіш</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="84"/>
+        <location filename="../preferences/preferencesdialog.ui" line="100"/>
         <source>Tree View</source>
         <translation>Дерево</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="90"/>
+        <location filename="../preferences/preferencesdialog.ui" line="106"/>
         <source>Identical Diff:</source>
         <translation>Однаковий:</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="110"/>
+        <location filename="../preferences/preferencesdialog.ui" line="126"/>
         <source>Moderate Diff:</source>
         <translation>Посередній:</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="130"/>
+        <location filename="../preferences/preferencesdialog.ui" line="146"/>
         <source>Huge Diff:</source>
         <translation>Істотно різні:</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="150"/>
+        <location filename="../preferences/preferencesdialog.ui" line="166"/>
         <source>Not Present Diff:</source>
         <translation>Відсутній:</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="170"/>
+        <location filename="../preferences/preferencesdialog.ui" line="186"/>
         <source>Transparency:</source>
         <translation>Прозорість:</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="187"/>
+        <location filename="../preferences/preferencesdialog.ui" line="203"/>
         <source>Text View</source>
         <translation>Текстовий вигляд</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="193"/>
+        <location filename="../preferences/preferencesdialog.ui" line="209"/>
         <source>Keywords:</source>
         <translation>Ключові слова:</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="213"/>
+        <location filename="../preferences/preferencesdialog.ui" line="229"/>
         <source>JSON Keys:</source>
         <translation>JSON ключі:</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="264"/>
-        <location filename="../preferences/preferencesdialog.ui" line="449"/>
+        <location filename="../preferences/preferencesdialog.ui" line="280"/>
+        <location filename="../preferences/preferencesdialog.ui" line="588"/>
         <source>Restore Defaults</source>
         <translation>Скинути</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="350"/>
+        <location filename="../preferences/preferencesdialog.ui" line="366"/>
         <source>Tabs Position</source>
         <translation>Розташування вкладок</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="358"/>
+        <location filename="../preferences/preferencesdialog.ui" line="374"/>
         <source>North</source>
         <translation>Північ</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="371"/>
+        <location filename="../preferences/preferencesdialog.ui" line="387"/>
         <source>South</source>
         <translation>Південь</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="381"/>
+        <location filename="../preferences/preferencesdialog.ui" line="397"/>
         <source>West</source>
         <translation>Захід</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="391"/>
+        <location filename="../preferences/preferencesdialog.ui" line="407"/>
         <source>East</source>
         <translation>Схід</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="312"/>
+        <location filename="../preferences/preferencesdialog.ui" line="439"/>
+        <source>Application style:</source>
+        <translation>Стиль інтерфейсу:</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="446"/>
+        <source>Pick the Qt style used by the whole application. &quot;Default&quot; lets Qt choose the platform default.</source>
+        <translation>Оберіть стиль Qt стиль що використовується для всієї програми. &quot;За замовчуванням&quot; Qt обере стиль залежно від платформи.</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="468"/>
+        <source>Style change takes effect after restart.</source>
+        <translation>Зміна стилю застосується після перезапуску.</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="478"/>
+        <source>Use styled tree view</source>
+        <translation>Використовувати стилізований вид дерева</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="481"/>
+        <source>When on, JSON tree views get custom branch icons and hover/select gradients from qss/qjsontreeview.qss. Off (default) uses the plain platform look.</source>
+        <translation>Коли включено, JSON вид дерева використовує  картинки з qss/qjsontreeview.qss. вименкно (замовчування) використовує вигляд в залежності від платформи.</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="514"/>
+        <source>Enable inline editing in single-tree view</source>
+        <translation>Дозволити редагування в вьювері дерева</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="517"/>
+        <source>When on, keys, types and values can be edited inline on the single-tree tab. Add/Delete row actions also appear in the context menu.</source>
+        <translation>Коли включено; ключі, типи і значення можна редагувати. Також з&apos;являються додати/видалити дії в контекстному меню.</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="524"/>
+        <source>Enable inline editing in diff view</source>
+        <translation>Дозволити редагування в вьювері різниці</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="527"/>
+        <source>When on, both diff trees become editable. Push arrows resolve Huge differences and copy NotPresent rows to the other side; Delete here removes the selected row.</source>
+        <translation>Коли включене,  обидва дерева різниці доступні до редагування. Стрілки дозволяють вирішити велику різницю і копіювати  Відсутні рядки до іншої сторони; Видалити видаляє обраний рядок.</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.ui" line="328"/>
         <source>View Button Position</source>
         <translation>Позиція кнопки перегляду</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="320"/>
+        <location filename="../preferences/preferencesdialog.ui" line="336"/>
         <source>Show Bottom</source>
         <translation>Показати внизу</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.ui" line="333"/>
+        <location filename="../preferences/preferencesdialog.ui" line="349"/>
         <source>Top Inline only</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.cpp" line="86"/>
+        <location filename="../preferences/preferencesdialog.cpp" line="83"/>
+        <source>Default</source>
+        <translation>Замовчуванння</translation>
+    </message>
+    <message>
+        <location filename="../preferences/preferencesdialog.cpp" line="117"/>
         <source>Action</source>
         <translation>Дія</translation>
     </message>
     <message>
-        <location filename="../preferences/preferencesdialog.cpp" line="86"/>
+        <location filename="../preferences/preferencesdialog.cpp" line="117"/>
         <source>Shortcut</source>
         <translation>Сполучення</translation>
     </message>
@@ -205,102 +267,112 @@ Available styles:
         <translation>Скопіювати шлях</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="141"/>
-        <location filename="../qjsoncontainer.cpp" line="884"/>
+        <location filename="../qjsoncontainer.cpp" line="145"/>
+        <location filename="../qjsoncontainer.cpp" line="1016"/>
         <source>Show Json Text</source>
         <translation>Показати Json текст</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="125"/>
-        <location filename="../qjsoncontainer.cpp" line="126"/>
-        <location filename="../qjsoncontainer.cpp" line="1098"/>
+        <location filename="../qjsoncontainer.cpp" line="129"/>
+        <location filename="../qjsoncontainer.cpp" line="130"/>
+        <location filename="../qjsoncontainer.cpp" line="1230"/>
         <source>Expand</source>
         <translation>Розгорнути</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="130"/>
+        <location filename="../qjsoncontainer.cpp" line="44"/>
+        <source>Add child</source>
+        <translation>Додати нащадка</translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="45"/>
+        <source>Delete row</source>
+        <translation>Видалити рядок</translation>
+    </message>
+    <message>
+        <location filename="../qjsoncontainer.cpp" line="134"/>
         <source>Sort</source>
         <translation>Сортувати</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="148"/>
+        <location filename="../qjsoncontainer.cpp" line="152"/>
         <source>Serach for...</source>
         <translation>Шукати на...</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="149"/>
+        <location filename="../qjsoncontainer.cpp" line="153"/>
         <source>Enter text and press enter to search</source>
         <translation>Введіть текст та натисніть Enter щоб шукати</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="155"/>
+        <location filename="../qjsoncontainer.cpp" line="159"/>
         <source>Find Next</source>
         <translation>Знайти Наступне</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="165"/>
+        <location filename="../qjsoncontainer.cpp" line="169"/>
         <source>Check to make case sensitive</source>
         <translation>Натисніть, щоб зважати на регістр</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="199"/>
+        <location filename="../qjsoncontainer.cpp" line="203"/>
         <source>Select file or use URL to load json data</source>
         <translation>Оберіть файл або вставте посилання, щоб завантажити json</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="200"/>
+        <location filename="../qjsoncontainer.cpp" line="204"/>
         <source>Select file or use full path/URL and hit enter to load json data</source>
         <translation>Оберіть файл або вставте повний шлях/веб посилання і натисніть Enter, щоб завантажити json</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="854"/>
-        <location filename="../qjsoncontainer.cpp" line="1714"/>
+        <location filename="../qjsoncontainer.cpp" line="986"/>
+        <location filename="../qjsoncontainer.cpp" line="1846"/>
         <source>Start of json has been reached! Next item will be from the end</source>
         <translation>Досягнуто початку! Наступний елемент буде з кінця</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="854"/>
-        <location filename="../qjsoncontainer.cpp" line="1714"/>
+        <location filename="../qjsoncontainer.cpp" line="986"/>
+        <location filename="../qjsoncontainer.cpp" line="1846"/>
         <source>End of json has been reached! Next item will be from the start</source>
         <translation>Досягнуто кінця! Наступний елемент буде з початку</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="864"/>
+        <location filename="../qjsoncontainer.cpp" line="996"/>
         <source>&lt;b&gt;&lt;font &quot;color&quot;=red&gt;Text Not Found!&lt;/font&gt;&lt;/b&gt;</source>
         <translation>&lt;b&gt;&lt;font &quot;color&quot;=red&gt;Текст не знайдено!&lt;/font&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="895"/>
+        <location filename="../qjsoncontainer.cpp" line="1027"/>
         <source>Show Json View</source>
         <translation>Показати Json дерево</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="910"/>
+        <location filename="../qjsoncontainer.cpp" line="1042"/>
         <source>Open File</source>
         <translation>Відкрити файл</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="911"/>
+        <location filename="../qjsoncontainer.cpp" line="1043"/>
         <source>Files (*.json *.jsn *.txt);;All Files (*)</source>
         <translation>Файли (*.json *.jsn *.txt);;Всі файли (*)</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="160"/>
+        <location filename="../qjsoncontainer.cpp" line="164"/>
         <source>Find Previous</source>
         <translation>Знайти попереднє</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="208"/>
+        <location filename="../qjsoncontainer.cpp" line="212"/>
         <source>Reload</source>
         <translation>Перезавантажити JSON</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="45"/>
+        <location filename="../qjsoncontainer.cpp" line="49"/>
         <source>Expand Selected</source>
         <translation>Розгорнути обрані</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="46"/>
+        <location filename="../qjsoncontainer.cpp" line="50"/>
         <source>Collapse Selected</source>
         <translation>Згорнути обрані</translation>
     </message>
@@ -315,12 +387,12 @@ Available styles:
         <translation>Згорнути обране дерево</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="204"/>
+        <location filename="../qjsoncontainer.cpp" line="208"/>
         <source>Open file</source>
         <translation>Відкрити файл</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="142"/>
+        <location filename="../qjsoncontainer.cpp" line="146"/>
         <source>Switch between view modes</source>
         <translation>Перемкнути режим перегляду</translation>
     </message>
@@ -355,90 +427,90 @@ Available styles:
         <translation>Скопіювати форматований Json обране</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="483"/>
+        <location filename="../qjsoncontainer.cpp" line="589"/>
         <source>-&gt;|</source>
         <translation>-&gt;|</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="485"/>
-        <location filename="../qjsoncontainer.cpp" line="486"/>
+        <location filename="../qjsoncontainer.cpp" line="591"/>
+        <location filename="../qjsoncontainer.cpp" line="592"/>
         <source>Go to Next Diff</source>
         <translation>Йти до наступної різниці</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="488"/>
+        <location filename="../qjsoncontainer.cpp" line="594"/>
         <source>|&lt;-</source>
         <translation>|&lt;-</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="490"/>
-        <location filename="../qjsoncontainer.cpp" line="491"/>
+        <location filename="../qjsoncontainer.cpp" line="596"/>
+        <location filename="../qjsoncontainer.cpp" line="597"/>
         <source>Go to Previous Diff</source>
         <translation>Йти до попередньої різниці</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="974"/>
+        <location filename="../qjsoncontainer.cpp" line="1106"/>
         <source>&lt;b&gt;&lt;font color=&apos;red&apos;&gt;JSON parse error:&lt;/font&gt;&lt;/b&gt; </source>
         <translation>&lt;b&gt;&lt;font color=&apos;red&apos;&gt;Помилка розбору JSON:&lt;/font&gt;&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="1727"/>
+        <location filename="../qjsoncontainer.cpp" line="1859"/>
         <source>&lt;b&gt;&lt;font &quot;color&quot;=green&gt;Documents identical!&lt;/font&gt;&lt;/b&gt;</source>
         <translation>&lt;b&gt;&lt;font &quot;color&quot;=green&gt;Документи ідентичні!&lt;/font&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="1732"/>
+        <location filename="../qjsoncontainer.cpp" line="1864"/>
         <source>&lt;b&gt;&lt;font &quot;color&quot;=yellow&gt;Start Comparison!&lt;/font&gt;&lt;/b&gt;</source>
         <translation>&lt;b&gt;&lt;font &quot;color&quot;=yellow&gt;Запустіть порівняння!&lt;/font&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="131"/>
+        <location filename="../qjsoncontainer.cpp" line="135"/>
         <source>Sort objects inside array
 It can be helpful for comparison when order does not relevant</source>
         <translation>Сортувати об&apos;єкти всередині масиву. Це може бути корисним для порівняння і коли порядок не має значення</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="136"/>
+        <location filename="../qjsoncontainer.cpp" line="140"/>
         <source>Switch View</source>
         <translation>Перемкнути режим перегляду</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="137"/>
+        <location filename="../qjsoncontainer.cpp" line="141"/>
         <source>Switch between tree/text view</source>
         <translation>Перемкнутись між дерево/текст режимами</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="152"/>
+        <location filename="../qjsoncontainer.cpp" line="156"/>
         <source>&gt;&gt;</source>
         <translation>&gt;&gt;</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="153"/>
+        <location filename="../qjsoncontainer.cpp" line="157"/>
         <source>Search Next</source>
         <translation>Шукати наступний</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="157"/>
+        <location filename="../qjsoncontainer.cpp" line="161"/>
         <source>&lt;&lt;</source>
         <translation>&lt;&lt;</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="163"/>
+        <location filename="../qjsoncontainer.cpp" line="167"/>
         <source>Search case sensetive</source>
         <translation>Пошук чутливий до регістру</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="1089"/>
+        <location filename="../qjsoncontainer.cpp" line="1221"/>
         <source>Collapse</source>
         <translation>Згорнути</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="158"/>
+        <location filename="../qjsoncontainer.cpp" line="162"/>
         <source>Search Previous</source>
         <translation>Шукати попередній</translation>
     </message>
     <message>
-        <location filename="../qjsoncontainer.cpp" line="494"/>
+        <location filename="../qjsoncontainer.cpp" line="600"/>
         <source>Amount of Differences (without root objects/arrays, means values only)</source>
         <translation>Кількість відмінностей (без кореневих об&apos;єктів/масивів, тобто тільки значення)</translation>
     </message>
@@ -446,47 +518,119 @@ It can be helpful for comparison when order does not relevant</source>
 <context>
     <name>QJsonDiff</name>
     <message>
-        <location filename="../qjsondiff.cpp" line="65"/>
+        <location filename="../qjsondiff.cpp" line="71"/>
         <source>Compare</source>
         <translation>Порівняти</translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="66"/>
+        <location filename="../qjsondiff.cpp" line="72"/>
         <source>Start comparison (ALT+C)</source>
         <translation>Розпочати порівняння (ALT+C)</translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="70"/>
+        <location filename="../qjsondiff.cpp" line="76"/>
         <source>Sync Scrolls</source>
         <translation>Синхронізувати прокрутку</translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="74"/>
+        <location filename="../qjsondiff.cpp" line="80"/>
         <source>Use Full Path</source>
         <translation>Вивористовувати повні шляхи</translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="76"/>
+        <location filename="../qjsondiff.cpp" line="82"/>
         <source>Otherwise try to find child+parent pair anywhere in JSON tree</source>
         <translation>Інакше намагатись знайти пари син+батько незважаючи на те, як глибоко вони в json дереві</translation>
     </message>
     <message>
+        <location filename="../qjsondiff.cpp" line="319"/>
+        <source>Building paths</source>
+        <translation>Будуємо шляхи</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="321"/>
+        <source>Matching paths</source>
+        <translation>Збіги шляхів</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="323"/>
+        <source>Comparing values</source>
+        <translation>Порівняння значень</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="325"/>
+        <source>Indexing right tree</source>
+        <translation>Індексування правого дерева</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="327"/>
+        <source>Pairing items</source>
+        <translation>Парування елементів</translation>
+    </message>
+    <message>
         <location filename="../qjsondiff.cpp" line="329"/>
+        <source>Resolving colors</source>
+        <translation>Розфарбовування</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="424"/>
         <source>Comparing JSON</source>
         <translation>Порівняння JSON</translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="330"/>
-        <source>Running comparison...</source>
-        <translation>Порівняння...</translation>
+        <location filename="../qjsondiff.cpp" line="436"/>
+        <source>Starting</source>
+        <translation>Починаємо</translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="331"/>
+        <location filename="../qjsondiff.cpp" line="505"/>
+        <source>Running comparison</source>
+        <translation>Відбувається порівняння</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="510"/>
+        <source>%1… (%2s)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="685"/>
+        <source>Push to right</source>
+        <translation>Записати вправо</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="686"/>
+        <source>Push selected row into the matching row on the right side (overwrites)</source>
+        <translation>Записати обраний рядок в відповідний рядок правої сторони (перезапис)</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="692"/>
+        <source>Push to left</source>
+        <translation>Записати в ліво</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="693"/>
+        <source>Push selected row into the matching row on the left side (overwrites)</source>
+        <translation>Записати обраний рядок в відповідний рядок лівої сторони (перезапис)</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="700"/>
+        <location filename="../qjsondiff.cpp" line="707"/>
+        <source>Delete here</source>
+        <translation>Видалити тут</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="701"/>
+        <location filename="../qjsondiff.cpp" line="708"/>
+        <source>Remove the selected row from this side. If it had a peer on the other side, the peer becomes NotPresent.</source>
+        <translation>Видалити обраний рядок з цієї сторони. Якщо є пов&apos;язаний елемент з іншої сторони, він стане відсутній.</translation>
+    </message>
+    <message>
+        <location filename="../qjsondiff.cpp" line="425"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../qjsondiff.cpp" line="71"/>
+        <location filename="../qjsondiff.cpp" line="77"/>
         <source>Try to sync left and right scrolling areas</source>
         <translation>Намагатись синхронізувати прокручування лівої і правої панелей</translation>
     </message>
@@ -494,17 +638,17 @@ It can be helpful for comparison when order does not relevant</source>
 <context>
     <name>QJsonModel</name>
     <message>
-        <location filename="../qjsonmodel.cpp" line="40"/>
+        <location filename="../qjsonmodel.cpp" line="45"/>
         <source>Name</source>
         <translation>Ім&apos;я</translation>
     </message>
     <message>
-        <location filename="../qjsonmodel.cpp" line="41"/>
+        <location filename="../qjsonmodel.cpp" line="46"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../qjsonmodel.cpp" line="42"/>
+        <location filename="../qjsonmodel.cpp" line="47"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across the documentation, build workflow, core diff engine, and UI behavior. The most significant changes are improvements to inline editing and diff resolution in the JSON diff view, expanded customization and preferences, and targeted optimizations to the CI workflow and diff engine API.

**Major highlights:**
- Inline editing and diff resolution are now opt-in, with detailed documentation and new public slots for custom shortcut binding.
- The diff engine (`JsonDiffEngine`) receives a comprehensive API expansion for fine-grained, incremental updates and edit handling.
- The build workflow is made more robust and maintainable, with improved environment variable handling and release note generation.
- Preferences and UI styling are now persisted and applied at startup.
- Documentation is updated to reflect new features, usage patterns, and terminology consistency.

---

### JSON Diff Engine Enhancements

* Added a suite of new static methods to `JsonDiffEngine` for incremental editing, peer copying, subtree resnapshotting, targeted color refresh, and path resolution, enabling efficient, fine-grained updates and live color refresh in the diff view.
* Introduced a `Phase` enum and associated `phaseChanged` signal for granular progress reporting and UI feedback during long-running operations. [[1]](diffhunk://#diff-5313b2619b022b137c26a063c059f70fe4500695bd02760b46cd1c6f4c443992R56-R69) [[2]](diffhunk://#diff-5313b2619b022b137c26a063c059f70fe4500695bd02760b46cd1c6f4c443992R227-R231)

### Inline Editing and Diff Resolution

* Inline editing is now opt-in and thoroughly documented, including new toolbar actions for resolving differences, deleting rows, and live color updates; all edit actions are exposed as public slots for custom shortcut binding. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R35) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L182-R204) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L197-R233)
* Improved `JsonItemDelegate` to use the canonical type name directly from the model, ensuring correct editor state regardless of display formatting.

### Preferences and UI Customization

* Preferences for UI colors, tab/button positions, keyboard shortcuts, and editing toggles are now configurable and persisted via `QSettings`, with the chosen Qt style applied at startup for consistent theming. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R57) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR115-R121)
* Application version bumped to `0.92`.

### Build Workflow Improvements

* Enhanced the GitHub Actions workflow for robustness: environment variables are now set explicitly, release notes are generated to a file and attached directly, and shell safety flags are enforced. [[1]](diffhunk://#diff-71a71e993dac5ebcaa1ad57402f04ee226b14121a8052e4f994706670fd65a1aR23-R26) [[2]](diffhunk://#diff-71a71e993dac5ebcaa1ad57402f04ee226b14121a8052e4f994706670fd65a1aR52-R71) [[3]](diffhunk://#diff-71a71e993dac5ebcaa1ad57402f04ee226b14121a8052e4f994706670fd65a1aR80-R89)
* Added `qt6-image-formats-plugins` to Linux build dependencies for improved Qt6 support.

### Documentation Updates and Terminology

* Expanded and clarified documentation in `README.md` and `CLAUDE.md` to reflect new features, usage, and terminology (e.g., "behavior" spelling, detailed edit/diff instructions). [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L57-R57) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L182-R182) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R35) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R57) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L182-R204) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L197-R233)

---

These changes collectively improve the flexibility, usability, and maintainability of the project, with a particular focus on making advanced diff and editing workflows accessible and robust.