### PR TITLE
Improve search functionality with progress bar and reset on edit

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -12,7 +12,7 @@
 #include <QTimer>
 #include <QtDebug>
 
-const QString APP_VERSION = "0.93";
+const QString APP_VERSION = "0.94";
 
 void qtJsonDiffLogger(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {

--- a/qjsoncontainer.cpp
+++ b/qjsoncontainer.cpp
@@ -152,6 +152,25 @@ QJsonContainer::QJsonContainer(QWidget *parent):
     find_lineEdit->setPlaceholderText(tr("Serach for..."));
     find_lineEdit->setToolTip(tr("Enter text and press enter to search"));
     find_lineEdit->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+
+    // Thin progress bar directly under the search input. Fires while
+    // findModelText is walking the tree; goes idle once the index is
+    // built — also serves as a visual "search is ready" cue.
+    mSearchProgress = new QProgressBar();
+    mSearchProgress->setMaximumHeight(3);
+    mSearchProgress->setTextVisible(false);
+    mSearchProgress->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    mSearchProgress->hide();
+
+    // Wrap line-edit + progress bar in a compact widget so the toolbar
+    // can host them as one item. Zero margins/spacing so the bar hugs
+    // the line-edit's bottom edge.
+    auto *findWrapper = new QWidget();
+    auto *findWrapperLayout = new QVBoxLayout(findWrapper);
+    findWrapperLayout->setContentsMargins(0, 0, 0, 0);
+    findWrapperLayout->setSpacing(0);
+    findWrapperLayout->addWidget(find_lineEdit);
+    findWrapperLayout->addWidget(mSearchProgress);
     findNext_toolbutton = new QAction(toolbar);
     QIcon findNext_icon = QIcon(createPixmapFromText(tr(">>")));
     findNext_toolbutton->setText(tr("Search Next"));
@@ -174,7 +193,7 @@ QJsonContainer::QJsonContainer(QWidget *parent):
     toolbar->addAction(switchview_action);
     toolbar->addAction(expandAll_Checkbox);
     toolbar->addSeparator();
-    toolbar->addWidget(find_lineEdit);
+    toolbar->addWidget(findWrapper);
     toolbar->addAction(findPrevious_toolbutton);
     toolbar->addAction(findNext_toolbutton);
     toolbar->addAction(findCaseSensitivity_toolbutton);
@@ -913,7 +932,23 @@ void QJsonContainer::on_findCaseSensitivity_toolbutton_clicked()
 {
     currentFindIndexesList.clear();
     currentFindText = find_lineEdit->text();
+    // Same show/hide bracket as findTextJsonIndexHandler — the case-
+    // sensitivity toggle re-runs findModelText from scratch, so the
+    // user should get the same visual "indexing" cue.
+    const int totalNodes = countTreeNodes(model, QModelIndex());
+    mSearchProgressCounter = 0;
+    if (mSearchProgress)
+    {
+        mSearchProgress->setRange(0, totalNodes > 0 ? totalNodes : 1);
+        mSearchProgress->setValue(0);
+        mSearchProgress->show();
+    }
     currentFindIndexesList = findModelText(model, QModelIndex());
+    if (mSearchProgress)
+    {
+        mSearchProgress->setValue(mSearchProgress->maximum());
+        mSearchProgress->hide();
+    }
     currentFindIndexId = -1;
 }
 
@@ -938,7 +973,23 @@ void QJsonContainer::findTextJsonIndexHandler(bool direction)
         {
             currentFindIndexesList.clear();
             currentFindText = find_lineEdit->text();
+            // Show the thin progress bar under the search input while
+            // findModelText walks the tree. Determinate range = total
+            // node count so the fill correlates with actual progress.
+            const int totalNodes = countTreeNodes(model, QModelIndex());
+            mSearchProgressCounter = 0;
+            if (mSearchProgress)
+            {
+                mSearchProgress->setRange(0, totalNodes > 0 ? totalNodes : 1);
+                mSearchProgress->setValue(0);
+                mSearchProgress->show();
+            }
             currentFindIndexesList = findModelText(model, QModelIndex());
+            if (mSearchProgress)
+            {
+                mSearchProgress->setValue(mSearchProgress->maximum());
+                mSearchProgress->hide();
+            }
             currentFindIndexId = -1;
             qDebug() << "##################" << currentFindIndexesList;
         }
@@ -1523,6 +1574,19 @@ QStringList QJsonContainer::extractItemTextFromModel(const QModelIndex &parent)
     return retval;
 }
 
+int QJsonContainer::countTreeNodes(QJsonModel *model, const QModelIndex &parent) const
+{
+    if (!model) return 0;
+    int total = 0;
+    const int n = model->rowCount(parent);
+    for (int i = 0; i < n; ++i)
+    {
+        QModelIndex idx = model->index(i, 0, parent);
+        total += 1 + countTreeNodes(model, idx);
+    }
+    return total;
+}
+
 QList<QModelIndex> QJsonContainer::findModelText(QJsonModel *model, const QModelIndex &parent)
 {
     QList<QModelIndex> retindex;
@@ -1563,6 +1627,20 @@ QList<QModelIndex> QJsonContainer::findModelText(QJsonModel *model, const QModel
                             retindex << idx0;
 
                         }
+                    // Progress tick per visited node. Every 200 nodes we
+                    // update the bar and drain user-events-free ticks
+                    // through the event loop so the bar can repaint mid-
+                    // walk. ExcludeUserInputEvents keeps a stray click
+                    // from re-entering the search handler while we're
+                    // still building the index.
+                    ++mSearchProgressCounter;
+                    if (mSearchProgress && mSearchProgress->isVisible()
+                            && (mSearchProgressCounter % 200) == 0)
+                    {
+                        mSearchProgress->setValue(mSearchProgressCounter);
+                        QCoreApplication::processEvents(
+                            QEventLoop::ExcludeUserInputEvents);
+                    }
                     retindex << findModelText(model, idx0);
                 }
         }

--- a/qjsoncontainer.h
+++ b/qjsoncontainer.h
@@ -33,6 +33,7 @@
 #include <zlib.h>
 
 #include <QWidgetAction>
+#include <QProgressBar>
 
 typedef QList<QPair<QModelIndex, QColor> > QLinHeaderList;
 
@@ -128,6 +129,16 @@ private:
     QString currentFindText;
     int currentFindIndexId;
     void resetCurrentFind();
+    // Thin progress bar directly under find_lineEdit that lights up
+    // while findModelText walks the tree. Also serves as the "search
+    // is indexed / ready" visual cue — off = idle, filling = indexing.
+    QProgressBar *mSearchProgress = nullptr;
+    // Live counter used by findModelText to feed mSearchProgress. Zeroed
+    // before the walk, incremented on each visited node.
+    int mSearchProgressCounter = 0;
+    // Count every visitable node under `parent` (recursive rowCount sum).
+    // Used to size mSearchProgress before findModelText starts.
+    int countTreeNodes(QJsonModel *model, const QModelIndex &parent) const;
     void findTextJsonIndexHandler(bool direction);
     int currentGotoIndexId;
     QMenu myMenu;

--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -429,6 +429,11 @@ bool QJsonModel::setData(const QModelIndex &index, const QVariant &value, int ro
 
     emit dataChanged(index, index, {Qt::DisplayRole, Qt::EditRole});
     emit modelChanged();
+    // Key or value edited — search index and goto list on the container
+    // are keyed off the model's text. Notify so QJsonContainer::
+    // on_model_dataUpdated clears its caches; without this a search
+    // for the old text keeps finding the edited row.
+    emit dataUpdated();
     return true;
 }
 


### PR DESCRIPTION
This pull request introduces a user-visible improvement to the search experience in the JSON viewer/editor by adding a thin progress bar under the search input. This progress bar provides real-time feedback during large or deep tree searches, letting users know when indexing is in progress and when it is complete. The implementation includes new logic to count tree nodes, update the progress bar efficiently, and ensure UI responsiveness during searches.

**User interface enhancements:**

* Added a thin `QProgressBar` directly under the search input (`find_lineEdit`) to visually indicate when a search is in progress and when it is ready. The progress bar is shown while the tree is being indexed and hidden when indexing completes. (`qjsoncontainer.cpp`, `qjsoncontainer.h`) [[1]](diffhunk://#diff-673459d4cfbf53273002b9a400ee0f65849f75d543355c8a7f17d6ff9a8fb0ceR155-R173) [[2]](diffhunk://#diff-673459d4cfbf53273002b9a400ee0f65849f75d543355c8a7f17d6ff9a8fb0ceL177-R196) [[3]](diffhunk://#diff-c8c8a2b922453ca9e91db7dc0cc2ef9737b553e3be523c09d216e991892b0394R36) [[4]](diffhunk://#diff-c8c8a2b922453ca9e91db7dc0cc2ef9737b553e3be523c09d216e991892b0394R132-R141)

**Search progress logic:**

* Implemented `countTreeNodes()` to determine the total number of nodes in the tree, allowing the progress bar to accurately reflect search progress. (`qjsoncontainer.cpp`, `qjsoncontainer.h`)
* Updated `findModelText()` to incrementally update the progress bar every 200 nodes, using `QCoreApplication::processEvents` to keep the UI responsive during long searches. (`qjsoncontainer.cpp`)
* Ensured the progress bar is shown and hidden appropriately in both the search handler and the case sensitivity toggle, providing consistent feedback for all search operations. (`qjsoncontainer.cpp`) [[1]](diffhunk://#diff-673459d4cfbf53273002b9a400ee0f65849f75d543355c8a7f17d6ff9a8fb0ceR935-R951) [[2]](diffhunk://#diff-673459d4cfbf53273002b9a400ee0f65849f75d543355c8a7f17d6ff9a8fb0ceR976-R992)

**Miscellaneous:**

* Bumped the application version from `0.93` to `0.94` to reflect the new feature. (`main.cpp`)
* Emitted a new `dataUpdated()` signal from `QJsonModel::setData()` to ensure search and goto caches are cleared when the model's text changes. (`qjsonmodel.cpp`)show progressbar

reset on edit