### PR TITLE
Improve UI speed and add progress bar with version bump

### DIFF
--- a/jsondiffengine.cpp
+++ b/jsondiffengine.cpp
@@ -22,6 +22,9 @@
 #include <QHash>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
 #include <functional>
 
 namespace
@@ -575,9 +578,44 @@ QModelIndex resolveIndex(QJsonModel *model, const QList<int> &path)
     return idx;
 }
 
-void applyRecursive(const DiffNode &snap, QJsonModel *model,
-                    const QModelIndex &parent, QJsonModel *otherModel)
+// Chunk size for the yield-and-emit boundary inside applyRecursive.
+// Every this-many DiffNode visits, we emit applyProgress and pump the
+// event loop (user input excluded) so the tree view can repaint the
+// area coloured so far and the progress bar advances.
+static constexpr int kApplyChunkNodes = 512;
+
+// Count total nodes in a DiffNode tree so applyStarted can hand a
+// concrete range to the progress bar. Cheap - no allocations, one
+// walk of a tree that already lives in memory.
+static int countDiffNodes(const DiffNode &n)
 {
+    int total = 1;
+    for (const DiffNode &c : n.children) total += countDiffNodes(c);
+    return total;
+}
+
+void applyRecursive(const DiffNode &snap, QJsonModel *model,
+                    const QModelIndex &parent, QJsonModel *otherModel,
+                    int &done, int &phantoms, qint64 &yieldsNs)
+{
+    // Progress + yield boundary at the top of each call. Yields
+    // ExcludeUserInputEvents so clicks/keys can't re-enter apply
+    // while paint/timer events still deliver. Bit-mask test on the
+    // counter is cheaper than a modulo.
+    // `yieldsNs` accumulates the cumulative time spent inside
+    // processEvents so apply() can report walk-vs-yields split back
+    // to the UI (helps diagnose whether the wall-clock tail is
+    // dominated by our own work or by the queued paint drain).
+    ++done;
+    if ((done & (kApplyChunkNodes - 1)) == 0)
+    {
+        emit model->applyProgress(done, phantoms);
+        QElapsedTimer yieldTimer;
+        yieldTimer.start();
+        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+        yieldsNs += yieldTimer.nsecsElapsed();
+    }
+
     // Container with an alignment (arrayAlignment is populated on both
     // Arrays AND Objects - name kept for source compat; semantic is
     // "children pairing"). Bipartite pairs (myIdx, peerIdx). Two apply
@@ -639,7 +677,18 @@ void applyRecursive(const DiffNode &snap, QJsonModel *model,
             else
                 item->setIdxRelation(resolveIndex(otherModel,
                                                   snapChild.relationPath));
-            applyRecursive(snapChild, model, idx, otherModel);
+            // Collect for the goto / "N diffs" list. Filter mirrors
+            // QJsonContainer::fillGotoList so the container doesn't
+            // have to re-walk the tree after apply.
+            if (!item->isPhantom()
+                && snapChild.color != DiffColorType::None
+                && snapChild.color != DiffColorType::Identical
+                && item->type() != QJsonValue::Object
+                && item->type() != QJsonValue::Array)
+            {
+                model->appendDiffIndex(idx);
+            }
+            applyRecursive(snapChild, model, idx, otherModel, done, phantoms, yieldsNs);
         };
         auto insertPhantom = [&](int row, int peerIdx)
         {
@@ -651,6 +700,7 @@ void applyRecursive(const DiffNode &snap, QJsonModel *model,
             // when apply() later emits its (now removed) layoutChanged.
             QJsonTreeItem *ph = model->insertPhantomRow(parent, row);
             if (!ph) return;
+            ++phantoms;
             if (peerIdx != -1 && otherModel && !peerArrayPath.isEmpty())
             {
                 QList<int> phPeer = peerArrayPath;
@@ -719,19 +769,12 @@ void applyRecursive(const DiffNode &snap, QJsonModel *model,
                 applyRealAt(myIdx, myIdx);
             }
         }
-        // Repaint hint for the phantom-branch parent: color updates
-        // (setColorType) don't emit dataChanged themselves; emit one
-        // range signal spanning all rows so QTreeView repaints them
-        // without invalidating persistent indices (i.e. without
-        // collapsing expanded descendants).
-        const int nRows = model->rowCount(parent);
-        if (nRows > 0)
-        {
-            emit model->dataChanged(
-                model->index(0, 0, parent),
-                model->index(nRows - 1, model->columnCount() - 1, parent),
-                {Qt::BackgroundRole, Qt::DecorationRole, Qt::DisplayRole});
-        }
+        // Repaint is deferred to the container's viewport update
+        // driven by applyProgress / applyFinished. Firing dataChanged
+        // per container here (once for every internal node of the
+        // JSON) was the hot spot: ~30k emits × per-emit slot fan-out
+        // in QTreeView added up to seconds on 2MB inputs even in
+        // release builds, dominating the actual work.
         return;
     }
 
@@ -749,24 +792,25 @@ void applyRecursive(const DiffNode &snap, QJsonModel *model,
         else
             item->setIdxRelation(resolveIndex(otherModel, snapChild.relationPath));
 
-        applyRecursive(snapChild, model, idx, otherModel);
+        // Same collection filter as applyRealAt above. Same preorder
+        // as fillGotoList - self first, then descendants via the
+        // recursive call below.
+        if (!item->isPhantom()
+            && snapChild.color != DiffColorType::None
+            && snapChild.color != DiffColorType::Identical
+            && item->type() != QJsonValue::Object
+            && item->type() != QJsonValue::Array)
+        {
+            model->appendDiffIndex(idx);
+        }
+
+        applyRecursive(snapChild, model, idx, otherModel, done, phantoms, yieldsNs);
     }
 
-    // Same repaint hint as the phantom-branch above. Emitted after
-    // recursion so descendants have already picked up their colors,
-    // but this signal covers the direct children - QTreeView repaints
-    // them without a layoutChanged (which would nuke expansion state).
-    if (!snap.children.empty())
-    {
-        const int nRows = model->rowCount(parent);
-        if (nRows > 0)
-        {
-            emit model->dataChanged(
-                model->index(0, 0, parent),
-                model->index(nRows - 1, model->columnCount() - 1, parent),
-                {Qt::BackgroundRole, Qt::DecorationRole, Qt::DisplayRole});
-        }
-    }
+    // Same rationale as the phantom-branch return above: per-container
+    // dataChanged is the hot spot on huge trees. Repaint is driven
+    // instead by the container's applyProgress hook (viewport update
+    // between chunks) and by applyFinished (final full repaint).
 }
 
 } // anonymous namespace
@@ -782,10 +826,52 @@ void JsonDiffEngine::apply(const DiffNode &snap, QJsonModel *model, QJsonModel *
     // phantom inserts use proper begin/endInsertRows (via
     // QJsonModel::insertPhantomRow) and applyRecursive emits
     // per-parent dataChanged for the color updates.
-    applyRecursive(snap, model, QModelIndex(), otherModel);
+    //
+    // Yield-and-progress: on huge JSONs the walk itself can take
+    // seconds. applyRecursive emits applyProgress and yields to the
+    // event loop every kApplyChunkNodes visits so the tree view can
+    // paint the coloured-so-far region and the thin progress bar
+    // under the tree view can advance. User input is excluded from
+    // the pump so re-entry is impossible.
+    const int total = countDiffNodes(snap);
+    emit model->applyStarted(total);
+    // Fresh diff-nav list. applyRecursive populates it inline so the
+    // container doesn't need the post-apply fillGotoList walk.
+    model->resetDiffIndices();
+    int done = 0;
+    int phantoms = 0;
+    // Sub-phase timers so the container can display where the tail
+    // wall-clock time is going ("walk" vs. "yields" vs. "finished
+    // slot fan-out" vs. "dataUpdated slot fan-out"). Nanosecond
+    // resolution because the finished / dataUpdated emits can be
+    // sub-millisecond and would round to zero otherwise.
+    QElapsedTimer walkTimer;
+    walkTimer.start();
+    qint64 yieldsNs = 0;
+    applyRecursive(snap, model, QModelIndex(), otherModel,
+                   done, phantoms, yieldsNs);
+    const qint64 walkNs = walkTimer.nsecsElapsed();
+    // Final progress tick so the label reflects the last chunk (the
+    // yield boundary inside applyRecursive is bit-masked, so the tail
+    // 0..kApplyChunkNodes-1 nodes wouldn't otherwise get emitted).
+    emit model->applyProgress(done, phantoms);
+    QElapsedTimer finishedTimer;
+    finishedTimer.start();
+    emit model->applyFinished();
+    const qint64 finishedNs = finishedTimer.nsecsElapsed();
     // Counter on the peer container listens for dataUpdated to refresh
     // its "N diffs" label.
+    QElapsedTimer dataUpdatedTimer;
+    dataUpdatedTimer.start();
     emit model->dataUpdated();
+    const qint64 dataUpdatedNs = dataUpdatedTimer.nsecsElapsed();
+    // "Walk" reported excluding yields so the two are directly
+    // additive and the user can tell them apart. Everything in ms.
+    emit model->applyTimings(
+        int((walkNs - yieldsNs) / 1'000'000),
+        int(yieldsNs / 1'000'000),
+        int(finishedNs / 1'000'000),
+        int(dataUpdatedNs / 1'000'000));
 }
 
 void JsonDiffEngine::applyPath(const DiffNode &snap, QJsonModel *model,

--- a/main.cpp
+++ b/main.cpp
@@ -12,7 +12,7 @@
 #include <QTimer>
 #include <QtDebug>
 
-const QString APP_VERSION = "0.95";
+const QString APP_VERSION = "0.96";
 
 void qtJsonDiffLogger(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {

--- a/qjsoncontainer.cpp
+++ b/qjsoncontainer.cpp
@@ -254,7 +254,40 @@ QJsonContainer::QJsonContainer(QWidget *parent):
 
     //treeview_layout->addWidget(expandAll_Checkbox,0,Qt::AlignLeft);
     treeview_layout->addLayout(tools_layout);
-    treeview_layout->addWidget(treeview);
+    // Wrap treeview + status label + a thin progress bar so both
+    // hug the tree's bottom edge (mirrors the search-progress
+    // pattern under find_lineEdit). Both are hidden at rest;
+    // JsonDiffEngine::apply shows/updates/hides them via
+    // QJsonModel::apply* signals. Status label narrates what the
+    // walk is doing right now so it's obvious it isn't wedged.
+    mApplyStatus = new QLabel();
+    mApplyStatus->setTextFormat(Qt::PlainText);
+    mApplyStatus->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    mApplyStatus->hide();
+    mApplyProgress = new QProgressBar();
+    mApplyProgress->setMaximumHeight(3);
+    mApplyProgress->setTextVisible(false);
+    mApplyProgress->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    mApplyProgress->hide();
+    // Single-shot hide for the timing breakdown displayed after apply
+    // completes. Restart-able so a second apply (right side after
+    // left) refreshes both the text and the countdown.
+    mApplyStatusHideTimer = new QTimer(this);
+    mApplyStatusHideTimer->setSingleShot(true);
+    mApplyStatusHideTimer->setInterval(5000);
+    connect(mApplyStatusHideTimer, &QTimer::timeout, this, [this]()
+    {
+        mApplyStatus->hide();
+        mApplyProgress->hide();
+    });
+    auto *treeWrapper = new QWidget();
+    auto *treeWrapperLayout = new QVBoxLayout(treeWrapper);
+    treeWrapperLayout->setContentsMargins(0, 0, 0, 0);
+    treeWrapperLayout->setSpacing(0);
+    treeWrapperLayout->addWidget(treeview);
+    treeWrapperLayout->addWidget(mApplyStatus);
+    treeWrapperLayout->addWidget(mApplyProgress);
+    treeview_layout->addWidget(treeWrapper);
     treeview_layout->addWidget(viewjson_plaintext);
     treeview_layout->addWidget(showjson_pushbutton);
 
@@ -356,6 +389,82 @@ QJsonContainer::QJsonContainer(QWidget *parent):
     connect(findCaseSensitivity_toolbutton, &QAction::triggered, this, &QJsonContainer::on_findCaseSensitivity_toolbutton_clicked);
     connect(model, SIGNAL(dataUpdated()), this, SLOT(on_model_dataUpdated()));
     connect(model, &QJsonModel::modelChanged, this, &QJsonContainer::on_model_changed);
+
+    // Apply-progress bar + status label wiring. The engine emits
+    // these three from apply() on the main thread; slot bodies just
+    // poke the widgets. Status label narrates: "Colouring nodes
+    // N/M · P mismatch rows inserted", so the user sees that the
+    // walk is progressing (and what it's doing) rather than a bar
+    // that mysteriously advances for 30s.
+    connect(model, &QJsonModel::applyStarted, this, [this](int total)
+    {
+        mApplyProgress->setRange(0, total);
+        mApplyProgress->setValue(0);
+        mApplyStatus->setText(tr("Applying diff to tree: 0 / %1 nodes")
+                              .arg(total));
+        mApplyStatus->show();
+        mApplyProgress->show();
+    });
+    connect(model, &QJsonModel::applyProgress, this,
+            [this](int done, int phantoms)
+    {
+        mApplyProgress->setValue(done);
+        // Two branches only to spare the tr() lookup in the common
+        // case where the walk hasn't had to insert any placeholder
+        // rows yet - keeps the label short until it needs to grow.
+        if (phantoms > 0)
+        {
+            mApplyStatus->setText(tr("Applying diff to tree: %1 / %2 nodes "
+                                     "· %3 mismatch rows inserted")
+                                  .arg(done)
+                                  .arg(mApplyProgress->maximum())
+                                  .arg(phantoms));
+        }
+        else
+        {
+            mApplyStatus->setText(tr("Applying diff to tree: %1 / %2 nodes")
+                                  .arg(done)
+                                  .arg(mApplyProgress->maximum()));
+        }
+        // Cheap incremental feedback: schedule a viewport repaint so
+        // the colouring applied to the visible rows shows up between
+        // chunks. Qt coalesces update() into a single paint event, so
+        // ~185 update()s over the walk cost nothing compared to the
+        // ~30k dataChanged emits we used to fire per container.
+        treeview->viewport()->update();
+    });
+    connect(model, &QJsonModel::applyFinished, this, [this]()
+    {
+        // Final repaint covering the tail of the walk (nodes past the
+        // last progress chunk boundary). Same cheap update() call.
+        // Bar + status label stay visible - they hide via the
+        // applyTimings handler below, which formats the timing
+        // breakdown and starts a 5s countdown.
+        treeview->viewport()->update();
+    });
+    // Diagnostic: replace the "Applying ..." progress text with the
+    // wall-clock breakdown so the user can see where the just-ended
+    // apply spent its time (walk vs. yields vs. slot fan-out). The
+    // 5s countdown from mApplyStatusHideTimer takes it away.
+    connect(model, &QJsonModel::applyTimings, this,
+            [this](int walkMs, int yieldsMs, int finishedMs, int dataUpdatedMs)
+    {
+        // Compact "0.05s" style for small values, "27.4s" for big ones.
+        auto fmt = [](int ms) -> QString
+        {
+            if (ms < 1000) return QString::number(ms) + QStringLiteral(" ms");
+            return QString::number(ms / 1000.0, 'f', 1) + QStringLiteral(" s");
+        };
+        mApplyStatus->setText(tr("Applied: walk %1 · yields %2 · "
+                                 "finished %3 · dataUpdated %4")
+                              .arg(fmt(walkMs))
+                              .arg(fmt(yieldsMs))
+                              .arg(fmt(finishedMs))
+                              .arg(fmt(dataUpdatedMs)));
+        mApplyStatus->show();
+        mApplyProgress->show();
+        mApplyStatusHideTimer->start();
+    });
 
     connect(copyRow, &QAction::triggered, this, &QJsonContainer::onActionTriggered);
     connect(copyRows, &QAction::triggered, this, &QJsonContainer::onActionTriggered);
@@ -1825,6 +1934,14 @@ void QJsonContainer::on_model_dataUpdated()
     qDebug() << "model has been changed";
     resetCurrentFind();
     resetGoto();
+    // Take the fresh diff-nav list JsonDiffEngine::apply built inline
+    // as it walked. QList is COW so this is a cheap shallow copy.
+    // Skips the O(N) fillGotoList walk that used to run from
+    // gotoIndexHandler(true) right after every Compare.
+    if (model)
+        {
+            gotoIndexes_list = model->diffIndices();
+        }
     if (diffAmount_lineEdit)
         {
             diffAmountUpdate();

--- a/qjsoncontainer.h
+++ b/qjsoncontainer.h
@@ -34,6 +34,7 @@
 
 #include <QWidgetAction>
 #include <QProgressBar>
+#include <QTimer>
 
 #include "httprequestconfig.h"
 
@@ -147,6 +148,20 @@ private:
     // Live counter used by findModelText to feed mSearchProgress. Zeroed
     // before the walk, incremented on each visited node.
     int mSearchProgressCounter = 0;
+    // Thin progress bar under the tree view that lights up during
+    // JsonDiffEngine::apply. On huge JSONs the colouring walk +
+    // phantom-row inserts can take seconds; the bar advances via
+    // QJsonModel::applyStarted / applyProgress / applyFinished
+    // signals emitted from the engine. mApplyStatus (above the bar)
+    // narrates what the walk is doing right now - "Colouring nodes
+    // N/M · P mismatch rows inserted" - so the user can see it isn't
+    // wedged.
+    QProgressBar *mApplyProgress = nullptr;
+    QLabel       *mApplyStatus   = nullptr;
+    // Delayed-hide for the status label so the timing breakdown
+    // ("Applied: walk 27.4s ...") stays on screen long enough for
+    // the user to read it. Both bar and label hide when this fires.
+    QTimer       *mApplyStatusHideTimer = nullptr;
     // Count every visitable node under `parent` (recursive rowCount sum).
     // Used to size mSearchProgress before findModelText starts.
     int countTreeNodes(QJsonModel *model, const QModelIndex &parent) const;

--- a/qjsondiff.cpp
+++ b/qjsondiff.cpp
@@ -1543,15 +1543,27 @@ void QJsonDiff::recomputeAfterUserEdit(const QModelIndex &idx, bool onLeft)
     const QJsonValue::Type modelType = item->type();
     const QString modelValue = item->value();
 
+    const QJsonValue::Type oldType = myNode->type;
     const bool keyChanged   = (myNode->key   != modelKey);
-    const bool typeChanged  = (myNode->type  != modelType);
+    const bool typeChanged  = (oldType       != modelType);
     const bool valueChanged = (myNode->value != modelValue);
     if (!keyChanged && !typeChanged && !valueChanged) return;  // engine path already in sync
 
+    // Only Object/Array involvement reshapes the children list. A
+    // scalar->scalar type change (String -> Double, Bool -> Null,
+    // etc.) leaves children empty on both sides of the flip, so the
+    // targeted applyPath path used for value edits is enough and we
+    // can skip both resnapshotSubtree and the ~95k-node full apply.
+    const bool structuralTypeChange = typeChanged
+        && (oldType == QJsonValue::Object || oldType == QJsonValue::Array
+            || modelType == QJsonValue::Object
+            || modelType == QJsonValue::Array);
+
     // Sync snapshot scalar fields to model. Children get re-walked
-    // below if the type changed - Object↔Array conversion paths
-    // restructure the model's children list and the snapshot has to
-    // catch up so future incremental edits keep working.
+    // below if the type change is structural - Object <-> Array
+    // conversion paths restructure the model's children list and the
+    // snapshot has to catch up so future incremental edits keep
+    // working.
     myNode->key   = modelKey;
     myNode->type  = modelType;
     myNode->value = modelValue;
@@ -1572,16 +1584,17 @@ void QJsonDiff::recomputeAfterUserEdit(const QModelIndex &idx, bool onLeft)
     }
     else
     {
-        if (typeChanged)
+        if (structuralTypeChange)
         {
             // Children may have been added/removed by the model's
-            // type-conversion code. Re-walk so the snapshot subtree
+            // type-conversion code (Object <-> Array, or scalar
+            // becoming a container). Re-walk so the snapshot subtree
             // matches the model; any peer cross-link pointing INTO
             // the old subtree gets orphaned.
             JsonDiffEngine::resnapshotSubtree(*mySnap, myPath, myModel,
                                               *peerSnap);
         }
-        // Type or value drift: same identity, different content →
+        // Type or value drift: same identity, different content.
         // recomparePair lights up Huge on the pair and refreshes
         // ancestor Moderate state on both sides.
         if (!peerPathAtEdit.isEmpty())
@@ -1597,12 +1610,13 @@ void QJsonDiff::recomputeAfterUserEdit(const QModelIndex &idx, bool onLeft)
         }
     }
 
-    // Type change restructured the subtree - the full apply is needed
-    // so views pick up the new/removed child rows. Value edits and key
-    // renames only shift color+idxRelation along the edited path and
-    // its ancestors, so the targeted applyPath saves the layoutChanged
-    // cost that was making per-edit repaints hitch on ~10k-node trees.
-    if (typeChanged)
+    // Structural type change (Object <-> Array, or scalar <-> container)
+    // restructures children in the model; the full apply is needed so
+    // views pick up the new/removed child rows. Scalar-to-scalar type
+    // changes (String -> Double, Bool -> Null, etc.) leave children
+    // empty on both sides and behave like a value edit, so applyPath on
+    // the ancestor chain is sufficient and skips the ~95k-node walk.
+    if (structuralTypeChange)
     {
         JsonDiffEngine::apply(*mySnap,   myModel,   peerModel);
         JsonDiffEngine::apply(*peerSnap, peerModel, myModel);

--- a/qjsondiff.cpp
+++ b/qjsondiff.cpp
@@ -678,7 +678,12 @@ void QJsonDiff::onCompareFinished(QSharedPointer<DiffNode> left,
     updateRightPushAction();
     const qint64 tUpdateActions = et.elapsed();
 
-    qDebug().nospace()
+    // qInfo (not qDebug) so this survives QT_NO_DEBUG_OUTPUT in
+    // release. Users diagnosing large-JSON compares can launch from
+    // a terminal and see the full breakdown; those launching by
+    // double-click still get the per-tree timing from the status
+    // label under each tree (see QJsonContainer applyTimings hook).
+    qInfo().nospace()
         << "[compare-finish] applyLeft=" << tApplyLeft << "ms"
         << " applyRight=" << tApplyRight << "ms"
         << " gotoLeft=" << tGotoLeft << "ms"
@@ -1426,8 +1431,85 @@ void QJsonDiff::recomputeAfterRowsInserted(const QModelIndex &parent,
                                           mLastMode);
     }
 
-    JsonDiffEngine::apply(*mySnap,   myModel,   peerModel);
-    JsonDiffEngine::apply(*peerSnap, peerModel, myModel);
+    // Targeted apply for row inserts. The old code ran full apply()
+    // on both sides (95k+ nodes each) for a single-row edit, showing
+    // the progress bar for seconds even though only the ancestor
+    // chain and the new subtree actually needed touching. Instead:
+    //   1. Colour the newly-inserted subtree NotPresent (no peer)
+    //      and record its scalar leaves in the model's diff-nav list
+    //      so the "N diffs" counter and Ctrl-G navigation see them.
+    //   2. Clear stale arrayAlignment on the mutated parent (and its
+    //      peer if paired) so any future full apply falls to the
+    //      safe non-phantom branch instead of misleadingly indexing
+    //      into positions that no longer line up.
+    //   3. Refresh the ancestor colour cascade via applyPath on both
+    //      sides. applyPath emits per-cell dataChanged + one final
+    //      dataUpdated, no progress-bar signals.
+    // Skips the ~95k node walk entirely.
+    const int lastCol = myModel->columnCount() - 1;
+    // Non-container, non-phantom, non-Identical / None filter matches
+    // JsonDiffEngine::applyRecursive lines 675 and 796. Every leaf
+    // that qualifies goes into the diff-nav list.
+    std::function<void(QJsonTreeItem *, QModelIndex)> paintAndCollect =
+        [&](QJsonTreeItem *item, QModelIndex idx)
+    {
+        if (!item) return;
+        item->setColorType(DiffColorType::NotPresent);
+        item->setIdxRelation(QModelIndex());
+        if (!item->isPhantom()
+            && item->type() != QJsonValue::Object
+            && item->type() != QJsonValue::Array)
+        {
+            myModel->appendDiffIndex(idx);
+        }
+        for (int i = 0; i < item->childCount(); ++i)
+        {
+            QModelIndex childInner = myModel->index(i, 0, idx);
+            paintAndCollect(item->child(i), childInner);
+        }
+    };
+    for (int row = first; row <= last; ++row)
+    {
+        QModelIndex childIdx = myModel->index(row, 0, parent);
+        if (!childIdx.isValid()) continue;
+        paintAndCollect(myModel->itemFromIndex(childIdx), childIdx);
+        emit myModel->dataChanged(
+            childIdx,
+            myModel->index(row, lastCol, parent),
+            {Qt::BackgroundRole, Qt::DecorationRole, Qt::DisplayRole});
+    }
+    // Stale alignment: positions in arrayAlignment now index into
+    // shifted rows. Empty is safe (fallback branch of apply walks
+    // in order and inserts no phantoms). If a later full compare
+    // runs it will rebuild alignment from scratch.
+    parentSnap->arrayAlignment.clear();
+    if (!parentSnap->relationPath.isEmpty())
+    {
+        DiffNode *peerParent = peerSnap;
+        for (int step : parentSnap->relationPath)
+        {
+            if (step < 0 || step >= peerParent->children.size())
+            {
+                peerParent = nullptr;
+                break;
+            }
+            peerParent = &peerParent->children[step];
+        }
+        if (peerParent) peerParent->arrayAlignment.clear();
+    }
+    // Ancestor colour refresh. applyPath returns early on empty
+    // path so root-level inserts skip the walk (no ancestors to
+    // fix); we still emit dataUpdated ourselves so the container's
+    // "N diffs" counter picks up the appended leaves.
+    if (parentPath.isEmpty())
+        emit myModel->dataUpdated();
+    else
+        JsonDiffEngine::applyPath(*mySnap, myModel, parentPath, peerModel);
+    if (!parentSnap->relationPath.isEmpty())
+        JsonDiffEngine::applyPath(*peerSnap, peerModel,
+                                  parentSnap->relationPath, myModel);
+    else
+        emit peerModel->dataUpdated();
 }
 
 void QJsonDiff::recomputeAfterUserEdit(const QModelIndex &idx, bool onLeft)

--- a/qjsonitem.cpp
+++ b/qjsonitem.cpp
@@ -111,10 +111,18 @@ int QJsonTreeItem::childCount() const
 
 int QJsonTreeItem::row() const
 {
-    if (mParent)
-        return mParent->mChilds.indexOf(const_cast<QJsonTreeItem*>(this));
-
-    return 0;
+    if (!mParent)
+        return 0;
+    // Fast path: cache is fresh when parent still holds `this` at
+    // the remembered slot. Any insert/remove/reorder above us
+    // invalidates the slot check and we fall through to a one-time
+    // indexOf, refreshing the cache for subsequent reads.
+    if (mCachedRow >= 0
+        && mCachedRow < mParent->mChilds.size()
+        && mParent->mChilds.at(mCachedRow) == this)
+        return mCachedRow;
+    mCachedRow = mParent->mChilds.indexOf(const_cast<QJsonTreeItem*>(this));
+    return mCachedRow;
 }
 
 void QJsonTreeItem::setKey(const QString &key)

--- a/qjsonitem.cpp
+++ b/qjsonitem.cpp
@@ -25,6 +25,7 @@
 
 #include "qjsonitem.h"
 #include "preferences/preferences.h"
+#include <QLocale>
 
 
 QJsonTreeItem::QJsonTreeItem(QJsonTreeItem *parent)
@@ -255,6 +256,27 @@ QJsonValue::Type QJsonTreeItem::stringToType(const QString& typeName)
 }
 
 
+QString QJsonTreeItem::doubleToJsonString(double d)
+{
+    // 'f' format (fixed decimal, never scientific) with
+    // FloatingPointShortest precision (fewest digits that
+    // round-trip back to the same double). Rationale:
+    //   - 100000              -> "100000"  (NOT "1e+05" - Shortest
+    //                            with 'g' picks scientific because
+    //                            5 chars < 6, which is wrong for JSON
+    //                            display)
+    //   - 3.14                -> "3.14"    (no trailing noise like
+    //                            "3.1400000000000001" that 'g' 17
+    //                            would produce)
+    //   - 20240312114021932   -> "20240312114021932" (survives, was
+    //                            "2.02403e+16" via default '%g' 6)
+    //   - very-small 1e-15    -> "0.000000000000001" (long but
+    //                            decimal; edge case, JSON rarely
+    //                            carries such values as tree scalars)
+    return QLocale::c().toString(d, 'f',
+                                 QLocale::FloatingPointShortest);
+}
+
 QJsonTreeItem* QJsonTreeItem::load(const QJsonValue& value, QJsonTreeItem* parent)
 {
     QJsonTreeItem * rootItem = new QJsonTreeItem(parent);
@@ -290,7 +312,14 @@ QJsonTreeItem* QJsonTreeItem::load(const QJsonValue& value, QJsonTreeItem* paren
     }
     else
     {
-        rootItem->setValue(value.toVariant().toString());
+        // Doubles need the shortest-round-trip helper so large
+        // integer-like values (epoch-ms, sequence ids) survive
+        // load(). All other scalars go through QVariant which
+        // handles String / Bool / Null correctly.
+        if (value.isDouble())
+            rootItem->setValue(doubleToJsonString(value.toDouble()));
+        else
+            rootItem->setValue(value.toVariant().toString());
         rootItem->setType(value.type());
     }
 

--- a/qjsonitem.h
+++ b/qjsonitem.h
@@ -66,6 +66,12 @@ public:
     
     static QJsonValue::Type stringToType(const QString& typeName);
     static QJsonTreeItem* load(const QJsonValue& value, QJsonTreeItem * parent = nullptr);
+    // Format a double as the shortest round-trippable decimal so
+    // large integer-like values (e.g. epoch-ms 20240312114021934)
+    // do not degrade to "2.02403e+16" via default 6-digit '%g'.
+    // Used by load() and QJsonModel::replaceFromJson() to keep
+    // arrow-push and drag-drop identical.
+    static QString doubleToJsonString(double d);
 
 protected:
 

--- a/qjsonitem.h
+++ b/qjsonitem.h
@@ -82,6 +82,16 @@ private:
 
     QList<QJsonTreeItem*> mChilds;
     QJsonTreeItem * mParent;
+    // Self-healing row cache. Read by row(): fast path returns
+    // mCachedRow when the parent still holds `this` at that slot;
+    // any shift (insert/remove above us) makes the slot check fail,
+    // and row() falls back to indexOf() while refreshing the cache
+    // for subsequent lookups. mutable so row() can stay const.
+    // Kills the O(N indexOf) that used to bite whenever Qt or user
+    // code called .parent() on many indices under a big container
+    // (Ctrl+A on a 5000-child array, drag-and-drop, filter-proxy,
+    // etc). See project_apply_datachanged_hotspot.md.
+    mutable int mCachedRow = -1;
 
 
 };

--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -1086,3 +1086,13 @@ bool QJsonModel::dropMimeData(const QMimeData *data, Qt::DropAction action,
     QModelIndex newIdx = insertChildFromJson(parent, row, key, payload);
     return newIdx.isValid();
 }
+
+void QJsonModel::resetDiffIndices()
+{
+    mDiffIndices.clear();
+}
+
+void QJsonModel::appendDiffIndex(const QModelIndex &idx)
+{
+    mDiffIndices.append(idx);
+}

--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -256,7 +256,7 @@ bool QJsonModel::setData(const QModelIndex &index, const QVariant &value, int ro
                     } else if (item->value().toLower() == "false") {
                         newValue = "0";
                     } else {
-                        newValue = QString::number(item->value().toDouble());
+                        newValue = QJsonTreeItem::doubleToJsonString(item->value().toDouble());
                     }
                 } else {
                     newValue = QString::number(item->value().toDouble());
@@ -689,7 +689,7 @@ bool QJsonModel::replaceFromJson(const QModelIndex &target, const QJsonValue &so
     if (source.isString())
         item->setValue(source.toString());
     else if (source.isDouble())
-        item->setValue(QString::number(source.toDouble()));
+        item->setValue(QJsonTreeItem::doubleToJsonString(source.toDouble()));
     else if (source.isBool())
         item->setValue(source.toBool() ? QStringLiteral("true") : QStringLiteral("false"));
     else

--- a/qjsonmodel.h
+++ b/qjsonmodel.h
@@ -128,6 +128,17 @@ public:
 
     static const QString kItemMimeType;
 
+    // Diff-navigation index list. JsonDiffEngine::apply resets this
+    // at the top of its run and appends every index that qualifies
+    // as a "reportable diff row" (non-phantom scalar with color !=
+    // None/Identical) as applyRecursive walks the DiffNode tree.
+    // QJsonContainer hydrates its gotoIndexes_list from here on
+    // dataUpdated, so the container no longer needs the full-tree
+    // fillGotoList walk after every Compare.
+    void resetDiffIndices();
+    void appendDiffIndex(const QModelIndex &idx);
+    const QList<QModelIndex> &diffIndices() const { return mDiffIndices; }
+
 private:
     QJsonTreeItem * mRootItem;
     QStringList mHeaders;
@@ -136,6 +147,7 @@ private:
     QString mLastErrorMessage;
     int mLastErrorOffset = 0;
     bool mIsEditable = false;
+    QList<QModelIndex> mDiffIndices;
 
     void setParseError(bool hasError, const QString& msg, int offset);
     void generateJson(QJsonTreeItem *item, QJsonValue &value) const;
@@ -145,6 +157,28 @@ signals:
    void dataUpdated();
    void parseErrorChanged();
    void modelChanged();
+
+   // Progress hooks for JsonDiffEngine::apply. On huge JSONs the
+   // per-item colour/idxRelation walk + phantom-row inserts can
+   // take seconds; the container hooks a thin bar under the tree
+   // view onto these so the UI stays responsive (apply yields to
+   // the event loop between chunks) and the user sees progress.
+   // `phantoms` = number of alignment-placeholder rows inserted so
+   // far, exposed so the status label under the tree can tell the
+   // user *why* the walk is spending time (colouring vs. filling
+   // gaps for missing peer rows).
+   void applyStarted(int totalNodes);
+   void applyProgress(int done, int phantoms);
+   void applyFinished();
+   // Sub-phase timing for the just-completed apply(). Fired after
+   // applyFinished + dataUpdated so it carries every emit-side cost.
+   // Four ints (all milliseconds) keeps MOC happy without needing
+   // Q_DECLARE_METATYPE on a struct.
+   //   walkMs        - applyRecursive body, yield time excluded
+   //   yieldsMs      - cumulative processEvents drain time
+   //   finishedMs    - applyFinished slot fan-out (bar hide, viewport update, etc.)
+   //   dataUpdatedMs - dataUpdated slot fan-out (on_model_dataUpdated + anyone else)
+   void applyTimings(int walkMs, int yieldsMs, int finishedMs, int dataUpdatedMs);
 
 
 };

--- a/tests/compare/test_compare.cpp
+++ b/tests/compare/test_compare.cpp
@@ -953,6 +953,32 @@ private slots:
         QCOMPARE(R->itemFromIndex(resolvePath(R, {"keep"}))->idxRelation(),
                  resolvePath(L, {"keep"}));
     }
+
+    // Locks in that JsonDiffEngine::apply's inline-collected
+    // diffIndices() list matches what QJsonContainer::fillGotoList
+    // would produce - so QJsonContainer::on_model_dataUpdated can
+    // hydrate its gotoIndexes_list from the model without triggering
+    // the O(N) post-apply walk that used to freeze the UI.
+    void diffIndicesEqualsFillGotoList()
+    {
+        loadAndCompare(
+            R"({"a":1,"b":2,"c":{"x":1,"y":2},"d":[1,2,3]})",
+            R"({"a":1,"b":9,"c":{"x":1,"y":9},"d":[1,2,9,4]})",
+            true);
+
+        QJsonModel* L = diff->getLeftJsonModel();
+        QJsonModel* R = diff->getRightJsonModel();
+
+        QCOMPARE(L->diffIndices(),
+                 diff->left_cont->fillGotoList(L, QModelIndex()));
+        QCOMPARE(R->diffIndices(),
+                 diff->right_cont->fillGotoList(R, QModelIndex()));
+        // Sanity: the compare above produces at least one diff on
+        // each side, otherwise the equality above would be vacuously
+        // trivial (two empty lists).
+        QVERIFY(L->diffIndices().size() > 0);
+        QVERIFY(R->diffIndices().size() > 0);
+    }
 };
 
 int main(int argc, char* argv[])

--- a/tests/compare/test_compare.cpp
+++ b/tests/compare/test_compare.cpp
@@ -954,6 +954,212 @@ private slots:
                  resolvePath(L, {"keep"}));
     }
 
+    // Regression: large integer-valued doubles (epoch-ms, big sequence
+    // ids) used to degrade to "2.02403e+16" via default 6-digit '%g'
+    // formatting when loaded from JSON. QJsonTreeItem::load now uses
+    // FloatingPointShortest, which keeps every digit that round-trips
+    // back to the same double.
+    void loadPreservesLargeDoubleAsFullDigits()
+    {
+        QJsonModel m;
+        // 2^53 boundary: 9007199254740993 rounds to 9007199254740992
+        // in double. Anything up to 2^53 stays exact; the format helper
+        // has to emit the exact integer digits (no scientific form).
+        m.loadJson(R"({"ms":20240312114021932})");
+        QModelIndex idx = m.index(0, 0);
+        QVERIFY(idx.isValid());
+        QJsonTreeItem *item = m.itemFromIndex(idx);
+        QVERIFY(item);
+        QCOMPARE(item->type(), QJsonValue::Double);
+        QCOMPARE(item->value(), QString("20240312114021932"));
+    }
+
+    // Regression: replaceFromJson (used by the arrow-push path) also
+    // has to preserve precision. Was previously QString::number(double)
+    // with default 6-digit precision - producing "2.02403e+16" for the
+    // same value. Same fix as loadPreservesLargeDoubleAsFullDigits.
+    void replaceFromJsonPreservesLargeDouble()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"x":1})");
+        QModelIndex idx = m.index(0, 0);
+        QVERIFY(idx.isValid());
+        // 20240312114021932 = double representable, exact integer.
+        // Value large enough that any default '%g' formatting
+        // collapses to scientific and drops digits.
+        QVERIFY(m.replaceFromJson(idx, QJsonValue(20240312114021932.0)));
+        QJsonTreeItem *item = m.itemFromIndex(idx);
+        QVERIFY(item);
+        QCOMPARE(item->type(), QJsonValue::Double);
+        QCOMPARE(item->value(), QString("20240312114021932"));
+    }
+
+    // Regression: after arrow-pushing a large-double item across, the
+    // destination model's display value must match what a fresh
+    // loadJson would produce. Cross-check the two code paths.
+    void loadAndReplaceProduceSameLargeDoubleString()
+    {
+        QJsonModel loaded;
+        loaded.loadJson(R"({"x":20240312114021932})");
+        const QString viaLoad =
+            loaded.itemFromIndex(loaded.index(0, 0))->value();
+
+        QJsonModel replaced;
+        replaced.loadJson(R"({"x":0})");
+        QVERIFY(replaced.replaceFromJson(replaced.index(0, 0),
+                                         QJsonValue(20240312114021932.0)));
+        const QString viaReplace =
+            replaced.itemFromIndex(replaced.index(0, 0))->value();
+
+        QCOMPARE(viaLoad, viaReplace);
+        QCOMPARE(viaLoad, QString("20240312114021932"));
+    }
+
+    // Regression: small fractional doubles must not gain trailing
+    // noise digits. FloatingPointShortest emits the shortest
+    // round-trippable form: 3.14 stays "3.14", not "3.1400000000000001".
+    void smallDoubleStaysCompact()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"pi":3.14})");
+        QCOMPARE(m.itemFromIndex(m.index(0, 0))->value(),
+                 QString("3.14"));
+    }
+
+    // Regression: round integer values in the ~1e5..1e12 range must
+    // stay as decimal digits, not collapse to scientific form. Broke
+    // once already when the helper used 'g' + FloatingPointShortest;
+    // 'g' picks 'e' whenever the exponent form is fewer chars than
+    // fixed. "1e+05" is 5 chars, "100000" is 6, so 'g' Shortest chose
+    // "1e+05" for 100000 - obviously wrong for JSON display.
+    void roundIntegerDoublesStayDecimal()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"a":100000,"b":1000000,"c":123456789,"d":10})");
+        QCOMPARE(m.itemFromIndex(resolvePath(&m, {"a"}))->value(),
+                 QString("100000"));
+        QCOMPARE(m.itemFromIndex(resolvePath(&m, {"b"}))->value(),
+                 QString("1000000"));
+        QCOMPARE(m.itemFromIndex(resolvePath(&m, {"c"}))->value(),
+                 QString("123456789"));
+        QCOMPARE(m.itemFromIndex(resolvePath(&m, {"d"}))->value(),
+                 QString("10"));
+    }
+
+    // Regression: replaceFromJson path (arrow push) with the same
+    // round integer values - matches loadJson path so drag-drop and
+    // arrow-push produce identical display strings.
+    void replaceFromJsonRoundIntegersStayDecimal()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"x":0})");
+        QModelIndex idx = m.index(0, 0);
+        QVERIFY(m.replaceFromJson(idx, QJsonValue(100000.0)));
+        QCOMPARE(m.itemFromIndex(idx)->value(), QString("100000"));
+        QVERIFY(m.replaceFromJson(idx, QJsonValue(1000000.0)));
+        QCOMPARE(m.itemFromIndex(idx)->value(), QString("1000000"));
+    }
+
+    // Regression: user reports "if there was string 20240312114021934
+    // and set it double it will be 2.02403e+16". The type-change path
+    // in QJsonModel::setData converts the old string to double then
+    // formats it back to display. Was using QString::number(double)
+    // with default 6-digit precision, dropping the last 10 digits.
+    // Now routes through doubleToJsonString same as loadJson and
+    // replaceFromJson.
+    void typeChangeStringToDoublePreservesLargeInteger()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"ms":"20240312114021932"})");
+        QModelIndex msIdx = m.index(0, 0);
+        QVERIFY(msIdx.isValid());
+        QCOMPARE(m.itemFromIndex(msIdx)->type(), QJsonValue::String);
+
+        // Change type of "ms" from String to Double via col-1 setData.
+        // This is the code path JsonItemDelegate::setModelData drives
+        // when the user picks "Double" from the type combo box.
+        QModelIndex typeIdx = msIdx.siblingAtColumn(1);
+        QVERIFY(m.setData(typeIdx, QStringLiteral("Double"),
+                          Qt::EditRole));
+
+        QCOMPARE(m.itemFromIndex(msIdx)->type(), QJsonValue::Double);
+        QCOMPARE(m.itemFromIndex(msIdx)->value(),
+                 QString("20240312114021932"));
+    }
+
+    // Regression: the same type-change path with a round-integer
+    // string. Guards against a "1e+05"-style regression on the
+    // setData path specifically (already guarded on load and
+    // replaceFromJson paths).
+    void typeChangeStringToDoubleRoundIntegerStaysDecimal()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"n":"100000"})");
+        QModelIndex nIdx = m.index(0, 0);
+        QVERIFY(m.setData(nIdx.siblingAtColumn(1),
+                          QStringLiteral("Double"),
+                          Qt::EditRole));
+        QCOMPARE(m.itemFromIndex(nIdx)->type(), QJsonValue::Double);
+        QCOMPARE(m.itemFromIndex(nIdx)->value(), QString("100000"));
+    }
+
+    // Regression: negatives, zero, and tiny non-integer values.
+    // The 'f' + FloatingPointShortest choice has to handle sign and
+    // very small fractional parts without going scientific.
+    void doubleEdgeCasesStayDecimal()
+    {
+        QJsonModel m;
+        m.loadJson(R"({"neg":-42,"zero":0,"half":0.5,"tenth":0.1})");
+        QCOMPARE(m.itemFromIndex(resolvePath(&m, {"neg"}))->value(),
+                 QString("-42"));
+        QCOMPARE(m.itemFromIndex(resolvePath(&m, {"zero"}))->value(),
+                 QString("0"));
+        QCOMPARE(m.itemFromIndex(resolvePath(&m, {"half"}))->value(),
+                 QString("0.5"));
+        QCOMPARE(m.itemFromIndex(resolvePath(&m, {"tenth"}))->value(),
+                 QString("0.1"));
+    }
+
+    // Regression: scalar to scalar type change (e.g. String to Double)
+    // MUST NOT do a full apply. It only shifts colours along the
+    // ancestor chain, same as a value edit. Structural type changes
+    // (Object <-> Array, or scalar <-> container) still full-apply.
+    // We can't directly assert "apply was not called", but we CAN
+    // assert the colours are correct and the untouched siblings kept
+    // their state (the full-apply path used to touch every node).
+    void scalarTypeChangeDoesTargetedApply()
+    {
+        loadAndCompare(R"({"a":"42","b":"same","c":"same"})",
+                       R"({"a":42, "b":"same","c":"same"})", true);
+        diff->setDiffEditable(true);
+
+        QJsonModel *L = diff->getLeftJsonModel();
+        QJsonModel *R = diff->getRightJsonModel();
+
+        // Precondition: a differs (String vs Double), b/c are Identical.
+        QCOMPARE(colorAt(L, {"b"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"b"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(L, {"c"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"c"}), DiffColorType::Identical);
+
+        // Change left "a" from String to Double via setData on col 1.
+        // This is what JsonItemDelegate does when the user picks the
+        // combo box option; it's a scalar to scalar change so no
+        // children are created or destroyed.
+        QModelIndex aTypeIdx = resolvePath(L, {"a"}).siblingAtColumn(1);
+        QVERIFY(L->setData(aTypeIdx, QStringLiteral("Double"),
+                           Qt::EditRole));
+
+        // "a" pair is now type-Double on both sides but the left value
+        // string is "42" and right value string is "42" - matching after
+        // recomparePair. b and c stay Identical, which they were before,
+        // proving the targeted path didn't accidentally clobber them.
+        QCOMPARE(colorAt(L, {"b"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"b"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(L, {"c"}), DiffColorType::Identical);
+        QCOMPARE(colorAt(R, {"c"}), DiffColorType::Identical);
+    }
+
     // Locks in that JsonDiffEngine::apply's inline-collected
     // diffIndices() list matches what QJsonContainer::fillGotoList
     // would produce - so QJsonContainer::on_model_dataUpdated can


### PR DESCRIPTION
This pull request significantly improves the performance and user experience of applying diffs to large JSON trees. The main focus is on optimizing the diff application process by chunking the work, providing real-time progress feedback, and reducing unnecessary UI updates that previously caused major slowdowns. Additionally, a thin progress bar and status label have been added to the UI to inform users about the current operation and timings, and internal logging has been improved for better diagnostics.

**Performance and Progress Feedback Improvements:**

* The diff application process (`applyRecursive` in `jsondiffengine.cpp`) is now chunked: progress is emitted and the event loop is pumped every 512 nodes, allowing the UI to repaint and the progress bar to update smoothly during long operations. This prevents the UI from freezing on large JSONs. [[1]](diffhunk://#diff-60e7a2d2745b07d632277063349d54eea0a3e58ffa0591364369fc979b3528aaL578-R618) [[2]](diffhunk://#diff-60e7a2d2745b07d632277063349d54eea0a3e58ffa0591364369fc979b3528aaL785-R874)
* Per-container `dataChanged` signals that previously caused severe performance issues (thousands of emits per apply) have been removed. Repaints are now deferred and handled efficiently via progress hooks, dramatically reducing UI lag on large diffs. [[1]](diffhunk://#diff-60e7a2d2745b07d632277063349d54eea0a3e58ffa0591364369fc979b3528aaL722-R777) [[2]](diffhunk://#diff-60e7a2d2745b07d632277063349d54eea0a3e58ffa0591364369fc979b3528aaL752-R813)

**User Interface Enhancements:**

* A thin progress bar and status label have been added below the tree view in `QJsonContainer`. These provide real-time feedback on the diff application process, including node counts and inserted mismatch rows. The status label also shows a timing breakdown after completion and hides automatically after a short delay. [[1]](diffhunk://#diff-673459d4cfbf53273002b9a400ee0f65849f75d543355c8a7f17d6ff9a8fb0ceL257-R290) [[2]](diffhunk://#diff-673459d4cfbf53273002b9a400ee0f65849f75d543355c8a7f17d6ff9a8fb0ceR393-R468) [[3]](diffhunk://#diff-c8c8a2b922453ca9e91db7dc0cc2ef9737b553e3be523c09d216e991892b0394R151-R164)
* The diff navigation list is now built inline during the apply walk, eliminating a redundant O(N) post-processing step and improving responsiveness after comparisons. [[1]](diffhunk://#diff-60e7a2d2745b07d632277063349d54eea0a3e58ffa0591364369fc979b3528aaL642-R691) [[2]](diffhunk://#diff-673459d4cfbf53273002b9a400ee0f65849f75d543355c8a7f17d6ff9a8fb0ceR1937-R1944)

**Diagnostics and Logging:**

* Logging for compare/apply timings has been switched from `qDebug` to `qInfo`, ensuring timing output is visible even in release builds for users running from a terminal.
* The application version has been incremented to 0.96 to reflect these significant improvements.

**Codebase Maintenance:**

* Necessary Qt includes and member variables have been added to support the new progress and status UI elements. [[1]](diffhunk://#diff-60e7a2d2745b07d632277063349d54eea0a3e58ffa0591364369fc979b3528aaR25-R27) [[2]](diffhunk://#diff-c8c8a2b922453ca9e91db7dc0cc2ef9737b553e3be523c09d216e991892b0394R37)

These changes collectively make the application much more responsive and informative when working with large JSON files, and provide users with clear feedback and diagnostics during long-running operations.