### PR TITLE
Fix Curl crash and enhance comparison features

### DIFF
--- a/httprequestconfig.cpp
+++ b/httprequestconfig.cpp
@@ -22,11 +22,14 @@ HttpRequestConfig HttpRequestConfig::defaults()
 
 bool HttpRequestConfig::isDefault() const
 {
+    // url is a display concern (which endpoint the request targets),
+    // not part of the request-shape identity. A default GET with a
+    // URL is still a default GET; the badge on the toolbar button
+    // reflects the request configuration, not the address.
     const HttpRequestConfig d = defaults();
     return method == d.method
            && headers == d.headers
-           && body == d.body
-           && url.isEmpty();
+           && body == d.body;
 }
 
 void HttpRequestConfig::applyTo(QNetworkRequest &request) const

--- a/httprequestconfigwidget.cpp
+++ b/httprequestconfigwidget.cpp
@@ -313,11 +313,10 @@ HttpRequestConfig HttpRequestConfigWidget::readFormConfig() const
             c.headers.append(qMakePair(name, row.valueEdit->text()));
         }
     c.body = mBodyEdit->toPlainText().toUtf8();
-    // URL is not editable on the form tab - it belongs to the
-    // container's own filePath_lineEdit. We preserve any URL that
-    // came in via setConfig (e.g. from a cURL paste) implicitly via
-    // populateForm not clearing it - but here we're reading back
-    // from the form, so we leave it empty.
+    // URL rides through on mFormUrl - not exposed as a form widget,
+    // but remembered from setConfig / cURL-tab edits so tab switches
+    // and OK don't silently drop it.
+    c.url = mFormUrl;
     return c;
 }
 
@@ -339,6 +338,10 @@ void HttpRequestConfigWidget::populateForm(const HttpRequestConfig &config)
     // Body
     QSignalBlocker bBlock(mBodyEdit);
     mBodyEdit->setPlainText(QString::fromUtf8(config.body));
+
+    // Remember the URL that came in - readFormConfig replays it, so
+    // switching to the cURL tab regenerates text WITH the URL in it.
+    mFormUrl = config.url;
 
     updateBodyEnabledState();
 }
@@ -402,6 +405,9 @@ void HttpRequestConfigWidget::onTabChanged(int index)
                     return;
                 }
             mCurlParseWarning->hide();
+            // populateForm updates mFormUrl from c.url, so a URL the
+            // user typed into the cURL tab survives the tab flip and
+            // will be handed back by readFormConfig / config().
             populateForm(c);
         }
     emit configChanged();

--- a/httprequestconfigwidget.h
+++ b/httprequestconfigwidget.h
@@ -90,6 +90,13 @@ private:
     QPlainTextEdit *mCurlEdit = nullptr;
     QLabel *mCurlParseWarning = nullptr;
 
+    // URL is not editable on the form tab (it belongs to the
+    // container's own filePath_lineEdit), but the cURL tab both shows
+    // and parses it. Remember whatever URL came in via setConfig / a
+    // cURL-tab edit so switching tabs Form -> cURL -> Form -> cURL
+    // doesn't silently wipe it out of readFormConfig().
+    QString mFormUrl;
+
     // Shared buttons
     QPushButton *mResetButton = nullptr;
     QPushButton *mSaveButton = nullptr;

--- a/main.cpp
+++ b/main.cpp
@@ -12,7 +12,7 @@
 #include <QTimer>
 #include <QtDebug>
 
-const QString APP_VERSION = "0.96";
+const QString APP_VERSION = "0.97";
 
 void qtJsonDiffLogger(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -155,6 +155,19 @@ void MainWindow::differRightFileLoaded(const QString &path)
 
 void MainWindow::loadLastPaths()
 {
+    // Apply the persisted per-container cURL config BEFORE loadJsonFile
+    // so a URL fetch on startup carries the user's method / headers /
+    // body from the previous session - same ordering rule the CLI path
+    // uses in setDisplayMode. noHttpDefaults=true here: what we saved
+    // is exactly what the container last had (toCurlText), no need to
+    // re-merge factory GET headers.
+    applyCliConfigToContainer(differ->left_cont,
+                              PREF_INST->differLeftCurl,  true);
+    applyCliConfigToContainer(differ->right_cont,
+                              PREF_INST->differRightCurl, true);
+    applyCliConfigToContainer(messageJsonCont,
+                              PREF_INST->jsonContainerCurl, true);
+
     differ->loadLeftJsonFile(PREF_INST->differLeftPath);
     differ->loadRightJsonFile(PREF_INST->differRightPath);
     messageJsonCont->loadJsonFile(PREF_INST->jsonContainerPath);
@@ -175,6 +188,24 @@ void MainWindow::closeEvent(QCloseEvent *event)
     PREF_INST->activeTabIndex = ui->tabWidget->currentIndex();
     PREF_INST->mainWindowGeometry = saveGeometry();
     PREF_INST->mainWindowState = saveState();
+
+    // Snapshot each container's current HTTP request config as cURL
+    // text. Default GETs serialize to a bare "curl -X GET" - fine to
+    // save; loadLastPaths re-parses it back to defaults() shape.
+    // Rides on save() below, gated by the same "Restore on start"
+    // toggle at load time.
+    if (messageJsonCont)
+        PREF_INST->jsonContainerCurl =
+            messageJsonCont->requestConfig().toCurlText();
+    if (differ)
+        {
+            if (differ->left_cont)
+                PREF_INST->differLeftCurl =
+                    differ->left_cont->requestConfig().toCurlText();
+            if (differ->right_cont)
+                PREF_INST->differRightCurl =
+                    differ->right_cont->requestConfig().toCurlText();
+        }
 
     PREF_INST->save();
 

--- a/preferences/preferences.cpp
+++ b/preferences/preferences.cpp
@@ -55,6 +55,10 @@ void Preferences::load()
     differLeftPath = s.value("Saved_Paths/differ_left_path").toString();
     differRightPath = s.value("Saved_Paths/differ_right_path").toString();
 
+    jsonContainerCurl = s.value("Saved_Paths/json_container_curl").toString();
+    differLeftCurl    = s.value("Saved_Paths/differ_left_curl").toString();
+    differRightCurl   = s.value("Saved_Paths/differ_right_curl").toString();
+
     identicalDiffColor = s.value("identical_diff_color",DEF_IDENTICAL_DIFF_COLOR).value<QColor>();
     moderateDiffColor = s.value("moderate_diff_color", DEF_MODERATE_DIFF_COLOR).value<QColor>();
     hugeDiffColor = s.value("huge_diff_color", DEF_HUGE_DIFF_COLOR).value<QColor>();
@@ -104,6 +108,10 @@ void Preferences::save()
     s.setValue("Saved_Paths/json_container_path", jsonContainerPath);
     s.setValue("Saved_Paths/differ_left_path", differLeftPath);
     s.setValue("Saved_Paths/differ_right_path", differRightPath);
+
+    s.setValue("Saved_Paths/json_container_curl", jsonContainerCurl);
+    s.setValue("Saved_Paths/differ_left_curl",    differLeftCurl);
+    s.setValue("Saved_Paths/differ_right_curl",   differRightCurl);
 
     s.setValue("identical_diff_color", identicalDiffColor);
     s.setValue("moderate_diff_color", moderateDiffColor);

--- a/preferences/preferences.h
+++ b/preferences/preferences.h
@@ -50,6 +50,15 @@ public:
     QString differLeftPath;
     QString differRightPath;
 
+    // Per-container HTTP request config, serialized as cURL text.
+    // Written on app close from QJsonContainer::requestConfig(); read
+    // during loadLastPaths BEFORE loadJsonFile so URL fetches on
+    // startup carry the user's method/headers/body. Empty string
+    // means "no custom config" - container falls back to defaults().
+    QString jsonContainerCurl;
+    QString differLeftCurl;
+    QString differRightCurl;
+
     QColor identicalDiffColor;
     QColor moderateDiffColor;
     QColor hugeDiffColor;

--- a/qjsoncontainer.cpp
+++ b/qjsoncontainer.cpp
@@ -1691,10 +1691,37 @@ void QJsonContainer::setRequestConfig(const HttpRequestConfig &config)
 void QJsonContainer::on_configureRequest_toolButton_clicked()
 {
     HttpRequestConfigDialog dlg(this);
-    dlg.setConfig(mRequestConfig);
+
+    // Seed the dialog's URL from the address field so the cURL tab
+    // shows the actual endpoint the request will hit. One-way sync:
+    // UI -> cURL only when the address is a URL. A local file path
+    // in filePath_lineEdit is intentionally NOT pushed into cURL -
+    // curl doesn't know what to do with a bare filesystem path and
+    // it would render nonsense output.
+    HttpRequestConfig initial = mRequestConfig;
+    const QString addr = filePath_lineEdit ? filePath_lineEdit->text() : QString();
+    if (initial.url.isEmpty()
+        && (addr.contains(QLatin1String("http://"), Qt::CaseInsensitive)
+            || addr.contains(QLatin1String("https://"), Qt::CaseInsensitive)))
+        {
+            initial.url = addr;
+        }
+    dlg.setConfig(initial);
+
     if (dlg.exec() == QDialog::Accepted)
         {
-            setRequestConfig(dlg.config());
+            HttpRequestConfig cfg = dlg.config();
+            setRequestConfig(cfg);
+            // cURL -> UI URL sync (the reverse direction). If the
+            // dialog produced a URL, mirror it into the address
+            // field so the very next refresh hits the right
+            // endpoint. Don't trigger a fetch - visual sync only.
+            if (!cfg.url.isEmpty()
+                && filePath_lineEdit
+                && filePath_lineEdit->text() != cfg.url)
+                {
+                    filePath_lineEdit->setText(cfg.url);
+                }
         }
 }
 

--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -98,6 +98,11 @@ bool QJsonModel::loadJson(const QByteArray &json)
     {
         setParseError(true, parseError.errorString(), parseError.offset);
         beginResetModel();
+        // Prior-compare diff indices point at items we're about to
+        // delete; drop them here or QJsonContainer::on_model_dataUpdated
+        // will republish stale QModelIndexes as gotoIndexes_list and
+        // Ctrl-G will dereference freed items (phantom nav / crash).
+        mDiffIndices.clear();
         delete mRootItem;
         mRootItem = QJsonTreeItem::load(QJsonValue(QJsonDocument::fromJson((QString(
                                                                             "{\"Error\":\"") + QString(parseError.errorString() +
@@ -114,6 +119,7 @@ bool QJsonModel::loadJson(const QByteArray &json)
     if(!doc.isNull())
     {
         beginResetModel();
+        mDiffIndices.clear();
         delete mRootItem;
         if(doc.isObject())
         {


### PR DESCRIPTION
This pull request introduces several improvements to HTTP request configuration handling, persistence, and UI synchronization, as well as a bug fix for diff navigation. The main themes are improved persistence of per-container HTTP request settings (including method, headers, body, and URL), better synchronization between the cURL and form tabs in the request configuration dialog, and a fix for a potential crash in diff navigation. The application version is also bumped.

**Persistence and restoration of HTTP request configuration:**

* Added per-container HTTP request config persistence (`jsonContainerCurl`, `differLeftCurl`, `differRightCurl`) in `Preferences` as cURL text, saving on close and restoring on startup to ensure user settings (method, headers, body, URL) are preserved across sessions (`preferences/preferences.h`, `preferences/preferences.cpp`, `mainwindow.cpp`). [[1]](diffhunk://#diff-965d8b72025ad270d37c9af727e73e41f35f7afed1041ccd73f450b7a30d4511R53-R61) [[2]](diffhunk://#diff-86ce7eee085fc280c07736587e42f9a952851611ab4613e577b27c141280c977R58-R61) [[3]](diffhunk://#diff-86ce7eee085fc280c07736587e42f9a952851611ab4613e577b27c141280c977R112-R115) [[4]](diffhunk://#diff-e12fae2282221bbdc52470acd3d3170f13683567557cca988671189c88ba7c45R158-R170) [[5]](diffhunk://#diff-e12fae2282221bbdc52470acd3d3170f13683567557cca988671189c88ba7c45R192-R209)

**UI synchronization between cURL and form tabs:**

* Improved synchronization of the URL between the cURL and form tabs in `HttpRequestConfigWidget`, ensuring the URL is not lost when switching tabs and that it is correctly remembered and restored (`httprequestconfigwidget.cpp`, `httprequestconfigwidget.h`). [[1]](diffhunk://#diff-e688c2becb87942d5d74d40411813614169091c816445774f21840ca7e26a3c4L316-R319) [[2]](diffhunk://#diff-e688c2becb87942d5d74d40411813614169091c816445774f21840ca7e26a3c4R342-R345) [[3]](diffhunk://#diff-e688c2becb87942d5d74d40411813614169091c816445774f21840ca7e26a3c4R408-R410) [[4]](diffhunk://#diff-1e114796a4c68f350416326ffa805f6c7e20bc73f1efdda9eb2733197208e954R93-R99)
* When opening the HTTP request config dialog, the URL is seeded from the address field if it's an HTTP(S) URL, and changes made in the dialog are mirrored back to the address field for visual sync (`qjsoncontainer.cpp`).

**Request configuration logic:**

* Modified `HttpRequestConfig::isDefault()` to ignore the URL in default comparison, treating the URL as a display concern and not part of the request-shape identity (`httprequestconfig.cpp`).

**Bug fix:**

* Fixed a crash in diff navigation by clearing `mDiffIndices` before deleting the model root item on parse errors or successful loads in `QJsonModel::loadJson`, preventing navigation to freed memory (`qjsonmodel.cpp`). [[1]](diffhunk://#diff-b006452185c2ad1734386a7ac40701f60daa954c4ca61c0042312b44ac701709R101-R105) [[2]](diffhunk://#diff-b006452185c2ad1734386a7ac40701f60daa954c4ca61c0042312b44ac701709R122)

**Other:**

* Bumped the application version to `0.97` in `main.cpp`.